### PR TITLE
fix: preserve Local Graph navigation from Obsigen

### DIFF
--- a/src/adapters/Obsidian/openVaultNote.test.ts
+++ b/src/adapters/Obsidian/openVaultNote.test.ts
@@ -1,0 +1,59 @@
+jest.mock("obsidian", () => ({
+	TFile: class TFile {
+		path: string;
+
+		constructor(path: string) {
+			this.path = path;
+		}
+	},
+}));
+
+import { TFile } from "obsidian";
+import { openVaultNote } from "./openVaultNote";
+
+describe("openVaultNote", () => {
+	test("opens a vault note in a normal active leaf and waits for navigation", async () => {
+		let finishNavigation: () => void = () => undefined;
+		const navigation = new Promise<void>((resolve) => {
+			finishNavigation = resolve;
+		});
+		const openLinkText = jest.fn().mockReturnValue(navigation);
+		const app = { workspace: { openLinkText } } as any;
+		const file = Object.create(TFile.prototype) as TFile;
+		Object.assign(file, { path: "Notes/example.md" });
+
+		let settled = false;
+		const result = openVaultNote(app, file, "Current note.md").then(() => {
+			settled = true;
+		});
+
+		expect(openLinkText).toHaveBeenCalledWith(
+			"Notes/example.md",
+			"Current note.md",
+			false,
+			{ active: true }
+		);
+		await Promise.resolve();
+		expect(settled).toBe(false);
+
+		finishNavigation();
+		await result;
+		expect(settled).toBe(true);
+	});
+
+	test("does not navigate or throw when the file does not exist", async () => {
+		const openLinkText = jest.fn();
+		const app = { workspace: { openLinkText } } as any;
+		const warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+
+		await expect(
+			openVaultNote(app, null, "", "Notes/missing.md")
+		).resolves.toBeUndefined();
+
+		expect(openLinkText).not.toHaveBeenCalled();
+		expect(warn).toHaveBeenCalledWith(
+			"[Obsigen] Note not found: Notes/missing.md"
+		);
+		warn.mockRestore();
+	});
+});

--- a/src/adapters/Obsidian/openVaultNote.ts
+++ b/src/adapters/Obsidian/openVaultNote.ts
@@ -1,0 +1,19 @@
+import { App, TAbstractFile, TFile } from "obsidian";
+
+export async function openVaultNote(
+	app: App,
+	file: TAbstractFile | null | undefined,
+	sourcePath = "",
+	requestedPath?: string
+): Promise<void> {
+	if (!(file instanceof TFile)) {
+		console.warn(
+			`[Obsigen] Note not found: ${requestedPath ?? file?.path ?? "unknown"}`
+		);
+		return;
+	}
+
+	await app.workspace.openLinkText(file.path, sourcePath, false, {
+		active: true,
+	});
+}

--- a/src/core/notes/NoteGenerator.test.ts
+++ b/src/core/notes/NoteGenerator.test.ts
@@ -1,3 +1,4 @@
+import { TFile } from 'obsidian';
 import { NoteGenerator } from './NoteGenerator';
 
 describe('NoteGenerator', () => {
@@ -7,12 +8,16 @@ describe('NoteGenerator', () => {
 
   beforeEach(() => {
     // Prepare test data
-    mockCreate = jest.fn().mockResolvedValue({ path: '/mnt/c/Users/Jesús/Documents/vault/testFile.md' });
-    mockOpenLinkText = jest.fn();
+    const createdFile = Object.create(TFile.prototype) as TFile;
+    Object.assign(createdFile, { path: '/mnt/c/Users/Jesús/Documents/vault/testFile.md' });
+    mockCreate = jest.fn().mockResolvedValue(createdFile);
+    mockOpenLinkText = jest.fn().mockResolvedValue(undefined);
 
     const app = {
       vault: {
         create: mockCreate,
+        createFolder: jest.fn().mockResolvedValue(undefined),
+        getAbstractFileByPath: jest.fn().mockReturnValue(null),
       },
       workspace: {
         openLinkText: mockOpenLinkText,
@@ -40,6 +45,11 @@ describe('NoteGenerator', () => {
     expect(mockCreate).toHaveBeenCalledWith(expect.stringContaining(title), expect.any(String));
 
     expect(mockOpenLinkText).toHaveBeenCalledTimes(1);
-    expect(mockOpenLinkText).toHaveBeenCalledWith('/mnt/c/Users/Jesús/Documents/vault/testFile.md', '', false);
+    expect(mockOpenLinkText).toHaveBeenCalledWith(
+      '/mnt/c/Users/Jesús/Documents/vault/testFile.md',
+      '',
+      false,
+      { active: true },
+    );
   });
 });

--- a/src/core/notes/NoteGenerator.ts
+++ b/src/core/notes/NoteGenerator.ts
@@ -1,4 +1,5 @@
 import { App, Notice } from 'obsidian';
+import { openVaultNote } from '../../adapters/Obsidian/openVaultNote';
 
 export class NoteGenerator {
   app: App;
@@ -39,7 +40,7 @@ export class NoteGenerator {
     }
 
     new Notice(msg);
-    this.app.workspace.openLinkText(fileRef.path, '', false);
+    await openVaultNote(this.app, fileRef, '', pathToFile);
 
     // Reload the Calendar View leaf
     // const leaf = this.app.workspace.getRightLeaf(true);

--- a/src/core/notes/__mocks__/obsidian.ts
+++ b/src/core/notes/__mocks__/obsidian.ts
@@ -1,9 +1,13 @@
 // src/core/notes/__mocks__/obsidian.ts
 
-export const App = {
-  // Provide dummy implementations or values for the App module methods/properties used in your code
-};
+export const App = {};
 
-export const Notice = {
-  // Provide dummy implementations or values for the Notice module methods/properties used in your code
-};
+export class Notice {}
+
+export class TFile {
+  path: string;
+
+  constructor(path = '') {
+    this.path = path;
+  }
+}

--- a/src/core/notes/aniversario/Aniversario.test.ts
+++ b/src/core/notes/aniversario/Aniversario.test.ts
@@ -1,3 +1,4 @@
+import { TFile } from 'obsidian';
 import { Aniversario } from './Aniversario';
 
 describe('Aniversario', () => {
@@ -7,12 +8,16 @@ describe('Aniversario', () => {
 
   beforeEach(() => {
     // Prepare test data
-    mockCreate = jest.fn().mockResolvedValue({ path: '/mnt/c/Users/Jesús/Documents/vault/testFile.md' });
-    mockOpenLinkText = jest.fn();
+    const createdFile = Object.create(TFile.prototype) as TFile;
+    Object.assign(createdFile, { path: '/mnt/c/Users/Jesús/Documents/vault/testFile.md' });
+    mockCreate = jest.fn().mockResolvedValue(createdFile);
+    mockOpenLinkText = jest.fn().mockResolvedValue(undefined);
 
     const app = {
       vault: {
         create: mockCreate,
+        createFolder: jest.fn().mockResolvedValue(undefined),
+        getAbstractFileByPath: jest.fn().mockReturnValue(null),
       },
       workspace: {
         openLinkText: mockOpenLinkText,
@@ -39,7 +44,12 @@ describe('Aniversario', () => {
     expect(mockCreate).toHaveBeenCalledWith(expect.stringContaining(expectedTitle), expect.any(String));
 
     expect(mockOpenLinkText).toHaveBeenCalledTimes(1);
-    expect(mockOpenLinkText).toHaveBeenCalledWith('/mnt/c/Users/Jesús/Documents/vault/testFile.md', '', false);
+    expect(mockOpenLinkText).toHaveBeenCalledWith(
+      '/mnt/c/Users/Jesús/Documents/vault/testFile.md',
+      '',
+      false,
+      { active: true },
+    );
   });
 
 });

--- a/src/core/notes/bible/BibleView.ts
+++ b/src/core/notes/bible/BibleView.ts
@@ -1,5 +1,6 @@
 import { App, MetadataCache, TFile } from 'obsidian';
 import { useEffect, useState } from 'react';
+import { openVaultNote } from '../../../adapters/Obsidian/openVaultNote';
 import { CalendarIcon } from './../calendar/CalendarIcon';
 import { bibleStructure } from './BibleViewStructure';
 
@@ -73,14 +74,10 @@ export function getExternalBiblePassages(note: Note): BiblePassage[] {
 }
 
 // Abrir la nota correspondiente al hacer clic.
-export function handleNoteClick(app: App, notePath: string) {
+export async function handleNoteClick(app: App, notePath: string): Promise<void> {
     const file = app.vault.getAbstractFileByPath(notePath);
 
-    if (file instanceof TFile) {
-        app.workspace.getLeaf().openFile(file);
-    } else {
-        console.error(`File not found: ${notePath}`);
-    }
+    await openVaultNote(app, file, '', notePath);
 }
 
 // Lógica principal del calendario bíblico.

--- a/src/core/notes/bible/BibleViewChapters.ts
+++ b/src/core/notes/bible/BibleViewChapters.ts
@@ -1,4 +1,5 @@
-import { App, FileView, TFile } from "obsidian";
+import { App, TFile } from "obsidian";
+import { openVaultNote } from "../../../adapters/Obsidian/openVaultNote";
 import { BibleImage, bibleStructure } from "./BibleViewStructure";
 
 const IMAGE_FOLDER = "050 Anexos";
@@ -161,12 +162,12 @@ export async function getChapterNotes(
 	return notes;
 }
 
-export function openNote(
+export async function openNote(
 	app: App,
 	book: string,
 	chapterNumber: string,
 	verseRange: [number, number]
-) {
+): Promise<void> {
 	const folderPath =
 		book === "Salmos"
 			? `333 Biblia/${book}/`
@@ -184,34 +185,22 @@ export function openNote(
 	);
 
 	if (!noteFile) {
-		console.log(
-			`openNote: No se encontró ninguna nota con el rango de versículos ${verseRangeString} en ${folderPath}`
+		await openVaultNote(
+			app,
+			null,
+			"",
+			`${folderPath} (verses ${verseRangeString})`
 		);
 		return;
 	}
 
-	const openLeaves = app.workspace.getLeavesOfType("markdown");
-	const openFilePaths = openLeaves
-		.map((leaf) =>
-			leaf.view instanceof FileView ? leaf.view.file?.path : null
-		)
-		.filter((path) => path !== null);
-
-	if (openFilePaths.includes(noteFile.path)) {
-		const leaf = openLeaves.find(
-			(leaf) =>
-				leaf.view instanceof FileView &&
-				leaf.view.file?.path === noteFile.path
-		);
-		if (leaf) {
-			app.workspace.setActiveLeaf(leaf);
-		}
-	} else {
-		app.workspace.openLinkText(noteFile.path, "", true);
-	}
+	await openVaultNote(app, noteFile);
 }
 
-export function openLocationNote(app: App, location: string) {
+export async function openLocationNote(
+	app: App,
+	location: string
+): Promise<void> {
 	const sanitizedLocation = location.replace(/\[\[|\]\]/g, "");
 	const [mainLocation, alias] = sanitizedLocation.split("|");
 
@@ -224,32 +213,12 @@ export function openLocationNote(app: App, location: string) {
 		);
 
 	if (files.length === 0) {
-		console.log(
-			`openLocationNote: No se encontró ninguna nota con el nombre ${sanitizedLocation}`
-		);
+		await openVaultNote(app, null, "", sanitizedLocation);
 		return;
 	}
 
 	const noteFile = files[0];
-	const openLeaves = app.workspace.getLeavesOfType("markdown");
-	const openFilePaths = openLeaves
-		.map((leaf) =>
-			leaf.view instanceof FileView ? leaf.view.file?.path : null
-		)
-		.filter((path) => path !== null);
-
-	if (openFilePaths.includes(noteFile.path)) {
-		const leaf = openLeaves.find(
-			(leaf) =>
-				leaf.view instanceof FileView &&
-				leaf.view.file?.path === noteFile.path
-		);
-		if (leaf) {
-			app.workspace.setActiveLeaf(leaf);
-		}
-	} else {
-		app.workspace.openLinkText(noteFile.path, "", true);
-	}
+	await openVaultNote(app, noteFile);
 }
 
 export async function fetchChapterNotes(

--- a/src/core/notes/bible/BibleViewChaptersUI.tsx
+++ b/src/core/notes/bible/BibleViewChaptersUI.tsx
@@ -87,7 +87,7 @@ const BibleChaptersView: React.FC<Props> = ({ app, bookRefs, selectedBook, setSe
                                                         className="image-container"
                                                         onClick={(e) => {
                                                             e.preventDefault();
-                                                            openNote(app, book, chapterNumber, note.verseRange);
+                                                            void openNote(app, book, chapterNumber, note.verseRange);
                                                         }}
                                                     >
                                                         <img

--- a/src/core/notes/bible/BibleViewUI.tsx
+++ b/src/core/notes/bible/BibleViewUI.tsx
@@ -47,18 +47,13 @@ const BibleView: React.FC<Props> = ({ app, metadataCache, files }) => {
                                                     <h4>{pericope.title} ({pericope.verseRange[0]}-{pericope.verseRange[1]})</h4>
                                                     <div className="pericope-container" style={getBackgroundStyle(pericope.images)}>
                                                         <CalendarEventsBar
+                                                            app={app}
                                                             events={notesForPericope.map(note => ({
                                                                 title: note.title,
                                                                 path: note.path,
                                                                 icon: note.icon,
                                                                 externalPassagesCount: getExternalBiblePassages(note).length, // Añadimos el número de pasajes externos
                                                             }))}
-                                                            onEventClick={(path) => {
-                                                                const file = app.vault.getAbstractFileByPath(path);
-                                                                if (file instanceof TFile) {
-                                                                    app.workspace.getLeaf().openFile(file);
-                                                                }
-                                                            }}
                                                         />
                                                         <ExternalBiblePassagesBar
                                                             externalPassages={notesForPericope.flatMap(note => getExternalBiblePassages(note))}

--- a/src/core/notes/bible/CalendarEventsBar.ts
+++ b/src/core/notes/bible/CalendarEventsBar.ts
@@ -1,4 +1,5 @@
 import { App, TFile } from 'obsidian';
+import { openVaultNote } from '../../../adapters/Obsidian/openVaultNote';
 import { CalendarIcon } from './../calendar/CalendarIcon';
 import { getExternalBiblePassages } from './ExternalBiblePassagesBar'; // Importar función para obtener los pasajes externos
 
@@ -27,12 +28,8 @@ export function getCalendarEvents(files: TFile[]): EventNote[] {
     });
 }
 
-export function handleNoteClick(app: App, notePath: string) {
+export async function handleNoteClick(app: App, notePath: string): Promise<void> {
     const file = app.vault.getAbstractFileByPath(notePath);
 
-    if (file instanceof TFile) {
-        app.workspace.getLeaf().openFile(file);
-    } else {
-        console.error(`File not found: ${notePath}`);
-    }
+    await openVaultNote(app, file, '', notePath);
 }

--- a/src/core/notes/bible/CalendarEventsBarUI.tsx
+++ b/src/core/notes/bible/CalendarEventsBarUI.tsx
@@ -1,25 +1,37 @@
+import { App } from 'obsidian';
 import React from 'react';
+import { openVaultNote } from '../../../adapters/Obsidian/openVaultNote';
 import { CalendarIcon } from './../calendar/CalendarIcon';
 
 interface CalendarEventsBarProps {
+  app: App;
   events: Array<{ title: string; path: string; icon?: React.ReactNode; externalPassagesCount: number }>;
-  onEventClick: (path: string) => void;
 }
 
-const CalendarEventsBar: React.FC<CalendarEventsBarProps> = ({ events, onEventClick }) => {
+const CalendarEventsBar: React.FC<CalendarEventsBarProps> = ({ app, events }) => {
   if (!events || events.length === 0) {
     return null; // No renderizar nada si no hay eventos
   }
+
+  const handleOpenNote = (
+    event: React.MouseEvent<HTMLAnchorElement>,
+    filePath: string,
+  ): void => {
+    event.preventDefault();
+    const file = app.vault.getAbstractFileByPath(filePath);
+    void openVaultNote(app, file, '', filePath);
+  };
 
   return (
     <div className="events-container">
       {events.map((event, index) => (
         <div key={index} className="event-icon-wrapper">
           <a
-            href={`obsidian://open?file=${encodeURIComponent(event.path)}`}
+            href="#"
+            onClick={(clickEvent) => handleOpenNote(clickEvent, event.path)}
             title={event.title} // Tooltip gestionado por Obsidian
           >
-            <div className="event-icon" onClick={() => onEventClick(event.path)}>
+            <div className="event-icon">
               {event.icon || CalendarIcon.getIcon('calendar', 12)}
               {event.externalPassagesCount > 0 && (
                 <span className="event-badge">{event.externalPassagesCount}</span> // Mostrar el número de pasajes externos

--- a/src/core/notes/calendar/Day.test.ts
+++ b/src/core/notes/calendar/Day.test.ts
@@ -1,0 +1,35 @@
+jest.mock("./CalendarEvent", () => ({
+	CalendarEvent: jest.fn(),
+}));
+
+jest.mock("./CalendarIcon", () => ({
+	CalendarIcon: {
+		getIconByNote: jest.fn(),
+	},
+}));
+
+import { getCalendarDayProps } from "./Day";
+
+describe("getCalendarDayProps", () => {
+	test("returns the internal vault path for the day's main note", () => {
+		const notePath = "100 Calendar/2026/2026-08-05.md";
+		const app = {
+			metadataCache: {
+				getFileCache: jest.fn(),
+			},
+		} as any;
+
+		const result = getCalendarDayProps({
+			year: 2026,
+			month: 8,
+			dayCounter: 5,
+			hasNote: notePath,
+			anniversaryNote: undefined,
+			dayNotes: false,
+			app,
+		});
+
+		expect(result.notePath).toBe(notePath);
+		expect(result.notePath).not.toContain("://");
+	});
+});

--- a/src/core/notes/calendar/Day.ts
+++ b/src/core/notes/calendar/Day.ts
@@ -70,7 +70,7 @@ export function getCalendarDayProps({
     dayNotes,
     app
 }: CalendarDayProps) {
-    const notePath = hasNote ? `obsidian://open?file=${encodeURIComponent(hasNote)}` : '';
+    const notePath = hasNote || '';
     const anniversary = anniversaryNote ? getCalendarEvent(year, month, dayCounter, generateEventIndex(anniversaryNote), anniversaryNote, app.metadataCache) : null;
 
     let notesOfTheDay = dayNotes ? dayNotes.map((note) => getCalendarEvent(year, month, dayCounter, generateEventIndex(note), note, app.metadataCache)) : null;
@@ -90,4 +90,3 @@ export function getCalendarDayProps({
         notesOfTheDay,
     };
 }
-

--- a/src/core/notes/calendar/DayUI.tsx
+++ b/src/core/notes/calendar/DayUI.tsx
@@ -1,4 +1,6 @@
 // src/core/notes/calendar/DayUI.tsx
+import React from 'react';
+import { openVaultNote } from '../../../adapters/Obsidian/openVaultNote';
 import { CalendarIcon } from './CalendarIcon';
 import { CalendarDayProps, getCalendarDayProps, getFileName, handleEventForm } from './Day';
 
@@ -13,8 +15,17 @@ const DayUI = ({ year, month, dayCounter, hasNote, anniversaryNote, dayNotes, ap
         app,
     });
 
+    const handleOpenNote = (
+        event: React.MouseEvent<HTMLAnchorElement>,
+        filePath: string,
+    ): void => {
+        event.preventDefault();
+        const file = app.vault.getAbstractFileByPath(filePath);
+        void openVaultNote(app, file, '', filePath);
+    };
+
     const btn = (
-        <div onClick={() => handleEventForm(app, year, month, dayCounter)}>
+        <div onClick={() => void handleEventForm(app, year, month, dayCounter)}>
             {CalendarIcon.getIcon("add", 18)}
         </div>
     );
@@ -23,7 +34,7 @@ const DayUI = ({ year, month, dayCounter, hasNote, anniversaryNote, dayNotes, ap
         <div className="day-container">
             {hasNote && !dayNotes ? (
                 <>
-                    <a href={notePath} title={getFileName(hasNote)}>
+                    <a href="#" onClick={(event) => handleOpenNote(event, notePath)} title={getFileName(hasNote)}>
                         <div className="day-number">{dayCounter}</div>
                     </a>
                     {btn}
@@ -31,7 +42,7 @@ const DayUI = ({ year, month, dayCounter, hasNote, anniversaryNote, dayNotes, ap
                         <div className="anniversary-note">
                             {anniversary && (
                                 <div key={anniversary.mykey} className={anniversary.dayContainerClasses}>
-                                    <a href={`obsidian://open?file=${encodeURIComponent(anniversary.path)}`} title={anniversary.fileName}>
+                                    <a href="#" onClick={(event) => handleOpenNote(event, anniversary.path)} title={anniversary.fileName}>
                                         {anniversary.icon}
                                         <span className="icon-description">{anniversary.fileName}</span>
                                     </a>
@@ -47,7 +58,7 @@ const DayUI = ({ year, month, dayCounter, hasNote, anniversaryNote, dayNotes, ap
                             <div className="anniversary-note">
                                 {anniversary && (
                                     <div key={anniversary.mykey} className={anniversary.dayContainerClasses}>
-                                        <a href={`obsidian://open?file=${encodeURIComponent(anniversary.path)}`} title={anniversary.fileName}>
+                                        <a href="#" onClick={(event) => handleOpenNote(event, anniversary.path)} title={anniversary.fileName}>
                                             {anniversary.icon}
                                             <span className="icon-description">{anniversary.fileName}</span>
                                         </a>
@@ -55,7 +66,7 @@ const DayUI = ({ year, month, dayCounter, hasNote, anniversaryNote, dayNotes, ap
                                 )}
                             </div>
                         )}
-                        <a href={notePath} title={getFileName(hasNote)}>
+                        <a href="#" onClick={(event) => handleOpenNote(event, notePath)} title={getFileName(hasNote)}>
                             <div className="day-number">{dayCounter}</div>
                         </a>
                         {btn}
@@ -63,7 +74,7 @@ const DayUI = ({ year, month, dayCounter, hasNote, anniversaryNote, dayNotes, ap
                     <div className="calendar-icons">
                         {notesOfTheDay?.map(note => (
                             <div key={note.mykey} className={note.dayContainerClasses}>
-                                <a href={`obsidian://open?file=${encodeURIComponent(note.path)}`} title={note.fileName}>
+                                <a href="#" onClick={(event) => handleOpenNote(event, note.path)} title={note.fileName}>
                                     {note.icon}
                                     <span className="icon-description">{note.fileName}</span>
                                 </a>
@@ -78,7 +89,7 @@ const DayUI = ({ year, month, dayCounter, hasNote, anniversaryNote, dayNotes, ap
                             <div className="anniversary-note">
                                 {anniversary && (
                                     <div key={anniversary.mykey} className={anniversary.dayContainerClasses}>
-                                        <a href={`obsidian://open?file=${encodeURIComponent(anniversary.path)}`} title={anniversary.fileName}>
+                                        <a href="#" onClick={(event) => handleOpenNote(event, anniversary.path)} title={anniversary.fileName}>
                                             {anniversary.icon}
                                             <span className="icon-description">{anniversary.fileName}</span>
                                         </a>
@@ -92,7 +103,7 @@ const DayUI = ({ year, month, dayCounter, hasNote, anniversaryNote, dayNotes, ap
                     <div className="calendar-icons">
                         {notesOfTheDay?.map(note => (
                             <div key={note.mykey} className={note.dayContainerClasses}>
-                                <a href={`obsidian://open?file=${encodeURIComponent(note.path)}`} title={note.fileName}>
+                                <a href="#" onClick={(event) => handleOpenNote(event, note.path)} title={note.fileName}>
                                     {note.icon}
                                     <span className="icon-description">{note.fileName}</span>
                                 </a>
@@ -107,7 +118,7 @@ const DayUI = ({ year, month, dayCounter, hasNote, anniversaryNote, dayNotes, ap
                         <div className="anniversary-note">
                             {anniversary && (
                                 <div key={anniversary.mykey} className={anniversary.dayContainerClasses}>
-                                    <a href={`obsidian://open?file=${encodeURIComponent(anniversary.path)}`} title={anniversary.fileName}>
+                                    <a href="#" onClick={(event) => handleOpenNote(event, anniversary.path)} title={anniversary.fileName}>
                                         {anniversary.icon}
                                         <span className="icon-description">{anniversary.fileName}</span>
                                     </a>

--- a/src/core/notes/timeline/Timeline.ts
+++ b/src/core/notes/timeline/Timeline.ts
@@ -1,4 +1,5 @@
-import { App, FileView, TFile } from "obsidian";
+import { App, TFile } from "obsidian";
+import { openVaultNote } from "../../../adapters/Obsidian/openVaultNote";
 
 const IMAGE_FOLDER = "050 Anexos";
 
@@ -151,35 +152,15 @@ export async function fetchChapterImages(
 	return images;
 }
 
-export function openNote(app: App, filePath: string) {
+export async function openNote(app: App, filePath: string): Promise<void> {
 	const noteFile = app.vault.getAbstractFileByPath(filePath);
-	if (!(noteFile instanceof TFile)) {
-		console.log(`openNote: No se encontró ninguna nota en ${filePath}`);
-		return;
-	}
-
-	const openLeaves = app.workspace.getLeavesOfType("markdown");
-	const openFilePaths = openLeaves
-		.map((leaf) =>
-			leaf.view instanceof FileView ? leaf.view.file?.path : null
-		)
-		.filter((path) => path !== null);
-
-	if (openFilePaths.includes(noteFile.path)) {
-		const leaf = openLeaves.find(
-			(leaf) =>
-				leaf.view instanceof FileView &&
-				leaf.view.file?.path === noteFile.path
-		);
-		if (leaf) {
-			app.workspace.setActiveLeaf(leaf);
-		}
-	} else {
-		app.workspace.openLinkText(noteFile.path, "", true);
-	}
+	await openVaultNote(app, noteFile, "", filePath);
 }
 
-export function openLocationNote(app: App, location: string) {
+export async function openLocationNote(
+	app: App,
+	location: string
+): Promise<void> {
 	const sanitizedLocation = location.replace(/\[\[|\]\]/g, "");
 	const [mainLocation, alias] = sanitizedLocation.split("|");
 
@@ -192,64 +173,18 @@ export function openLocationNote(app: App, location: string) {
 		);
 
 	if (files.length === 0) {
-		console.log(
-			`openLocationNote: No se encontró ninguna nota con el nombre ${sanitizedLocation}`
-		);
+		await openVaultNote(app, null, "", sanitizedLocation);
 		return;
 	}
 
 	const noteFile = files[0];
-	if (!(noteFile instanceof TFile)) {
-		return;
-	}
-
-	const openLeaves = app.workspace.getLeavesOfType("markdown");
-	const openFilePaths = openLeaves
-		.map((leaf) =>
-			leaf.view instanceof FileView ? leaf.view.file?.path : null
-		)
-		.filter((path) => path !== null);
-
-	if (openFilePaths.includes(noteFile.path)) {
-		const leaf = openLeaves.find(
-			(leaf) =>
-				leaf.view instanceof FileView &&
-				leaf.view.file?.path === noteFile.path
-		);
-		if (leaf) {
-			app.workspace.setActiveLeaf(leaf);
-		}
-	} else {
-		app.workspace.openLinkText(noteFile.path, "", true);
-	}
+	await openVaultNote(app, noteFile, "", sanitizedLocation);
 }
 
-export function openNoteByPath(app: App, filePath: string) {
+export async function openNoteByPath(
+	app: App,
+	filePath: string
+): Promise<void> {
 	const noteFile = app.vault.getAbstractFileByPath(filePath);
-	if (!(noteFile instanceof TFile)) {
-		console.log(
-			`openNoteByPath: No se encontró ninguna nota en ${filePath}`
-		);
-		return;
-	}
-
-	const openLeaves = app.workspace.getLeavesOfType("markdown");
-	const openFilePaths = openLeaves
-		.map((leaf) =>
-			leaf.view instanceof FileView ? leaf.view.file?.path : null
-		)
-		.filter((path) => path !== null);
-
-	if (openFilePaths.includes(noteFile.path)) {
-		const leaf = openLeaves.find(
-			(leaf) =>
-				leaf.view instanceof FileView &&
-				leaf.view.file?.path === noteFile.path
-		);
-		if (leaf) {
-			app.workspace.setActiveLeaf(leaf);
-		}
-	} else {
-		app.workspace.openLinkText(noteFile.path, "", true);
-	}
+	await openVaultNote(app, noteFile, "", filePath);
 }

--- a/src/core/notes/timeline/TimelineUI.tsx
+++ b/src/core/notes/timeline/TimelineUI.tsx
@@ -44,7 +44,7 @@ const TimelineView: React.FC<TimelineViewProps> = ({ app, bookRefs, selectedBook
                             <div className="timeline-element-content">
                                 <div className="timeline-text-container">
                                     <h3 className="vertical-timeline-element-title">
-                                        <a href="#" onClick={(e) => { e.preventDefault(); openNoteByPath(app, image.notePath); }}>
+                                        <a href="#" onClick={(e) => { e.preventDefault(); void openNoteByPath(app, image.notePath); }}>
                                             {image.title}
                                         </a>
                                     </h3>


### PR DESCRIPTION
## Summary

- centralizes internal note navigation through `openVaultNote`
- replaces unconditional new-leaf navigation and manual leaf scanning
- removes `obsidian://open` links used for ordinary vault notes
- preserves intentional Map View and Advanced URI integrations
- adds regression coverage for internal calendar paths and navigation arguments

## Root cause

Several Obsigen views opened notes through inconsistent mechanisms:

- `openLinkText(..., true)`
- manual Markdown leaf discovery and activation
- direct `getLeaf().openFile(...)`
- `obsidian://open?file=...` links

The protocol links bypassed the centralized navigation adapter and left Obsidian's Local Graph in a blank state after opening notes from Obsigen.

## User impact

Notes opened from Calendar, Timeline and Bible views now use normal active Markdown navigation. The Local Graph follows the selected note and continues working when navigation returns to Obsidian's native file explorer.

## Validation

- visual Local Graph workflow confirmed in Obsidian
- specific tests: 4/4 passed
- TypeScript and esbuild production build passed
- no `obsidian://open` or `obsidian://advanced-uri` remains for ordinary internal-note navigation
- generated plugin bundle installed successfully in the active vault

## Known pre-existing issue

The complete Jest suite still contains an unrelated existing failure:

`Aniversario.test.ts` fails in `Yaml.tsx` when calling `toString()` on `null`.

This PR does not modify that serialization behavior.
