### PR TITLE
fix: manage CalendarView React lifecycle

### DIFF
--- a/src/core/notes/calendar/CalendarView.test.ts
+++ b/src/core/notes/calendar/CalendarView.test.ts
@@ -1,0 +1,118 @@
+const mockCreateRoot = jest.fn();
+
+jest.mock('obsidian', () => ({
+  ItemView: class {
+    app: unknown;
+    contentEl: unknown;
+
+    constructor(leaf: { app: unknown; contentEl: unknown }) {
+      this.app = leaf.app;
+      this.contentEl = leaf.contentEl;
+    }
+  },
+}));
+
+jest.mock('react-dom/client', () => ({
+  __esModule: true,
+  default: {
+    createRoot: mockCreateRoot,
+  },
+}));
+
+jest.mock('../bible/BibleViewChaptersUI', () => () => null);
+jest.mock('../timeline/TimelineUI', () => () => null);
+jest.mock('./../ViewSwitcher', () => () => null);
+jest.mock('./CalendarYear', () => () => null);
+
+import { CalendarView } from './CalendarView';
+
+interface FakeRoot {
+  render: jest.Mock;
+  unmount: jest.Mock;
+}
+
+function createFakeRoot(): FakeRoot {
+  return {
+    render: jest.fn(),
+    unmount: jest.fn(),
+  };
+}
+
+function createView(querySelector = jest.fn().mockReturnValue(null)) {
+  const contentEl = { querySelector };
+  const leaf = {
+    app: {},
+    contentEl,
+  };
+
+  return new CalendarView(leaf as any);
+}
+
+describe('CalendarView lifecycle', () => {
+  beforeEach(() => {
+    mockCreateRoot.mockReset();
+  });
+
+  test('onOpen renders the view through its React root', async () => {
+    const root = createFakeRoot();
+    mockCreateRoot.mockReturnValue(root);
+    const view = createView();
+
+    await view.onOpen();
+
+    expect(mockCreateRoot).toHaveBeenCalledTimes(1);
+    expect(root.render).toHaveBeenCalledTimes(1);
+  });
+
+  test('onClose captures the current Bible scroll position', async () => {
+    const root = createFakeRoot();
+    const querySelector = jest.fn().mockReturnValue({ scrollTop: 123 });
+    mockCreateRoot.mockReturnValue(root);
+    const view = createView(querySelector);
+
+    await view.onClose();
+
+    expect(querySelector).toHaveBeenCalledWith('.bible-view-chapters');
+    expect((view as any).scrollPosition).toBe(123);
+  });
+
+  test('onClose unmounts the React root', async () => {
+    const root = createFakeRoot();
+    mockCreateRoot.mockReturnValue(root);
+    const view = createView();
+
+    await view.onOpen();
+    await view.onClose();
+
+    expect(root.unmount).toHaveBeenCalledTimes(1);
+  });
+
+  test('open-close-open uses a fresh valid root without accumulating roots', async () => {
+    const firstRoot = createFakeRoot();
+    const reopenedRoot = createFakeRoot();
+    mockCreateRoot
+      .mockReturnValueOnce(firstRoot)
+      .mockReturnValueOnce(reopenedRoot);
+    const view = createView();
+
+    await view.onOpen();
+    await view.onClose();
+    await view.onOpen();
+
+    expect(firstRoot.unmount).toHaveBeenCalledTimes(1);
+    expect(mockCreateRoot).toHaveBeenCalledTimes(2);
+    expect(reopenedRoot.render).toHaveBeenCalledTimes(1);
+  });
+
+  test('onOpen twice without close keeps one active root', async () => {
+    const root = createFakeRoot();
+    mockCreateRoot.mockReturnValue(root);
+    const view = createView();
+
+    await view.onOpen();
+    await view.onOpen();
+
+    expect(mockCreateRoot).toHaveBeenCalledTimes(1);
+    expect(root.render).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/core/notes/calendar/CalendarView.ts
+++ b/src/core/notes/calendar/CalendarView.ts
@@ -12,7 +12,7 @@ export const CONTAINER_ID = "obsigen-calendar-container";
 
 export class CalendarView extends ItemView {
     private reactComponent: React.ReactElement;
-    private root: ReactDOM.Root;
+    private root: ReactDOM.Root | null = null;
     private currentYear: number;
     private today: Date;
     private isBibleView: boolean;
@@ -34,7 +34,6 @@ export class CalendarView extends ItemView {
             [key: string]: HTMLDivElement | null;
         }>;
         this.selectedBook = ""; // Default to an empty string
-        this.root = ReactDOM.createRoot(this.contentEl as HTMLElement);
     }
 
     private handleAddEvent = async () => {
@@ -84,6 +83,10 @@ export class CalendarView extends ItemView {
     };
 
     private renderComponent() {
+        if (this.root === null) {
+            return;
+        }
+
         this.reactComponent = React.createElement(
             AppContext.Provider,
             { value: this.app },
@@ -137,10 +140,16 @@ export class CalendarView extends ItemView {
 
     async onOpen() {
         this.forceUpdate = true;
+        if (this.root === null) {
+            this.root = ReactDOM.createRoot(this.contentEl as HTMLElement);
+        }
+
         this.renderComponent();
     }
 
     async onClose() {
         this.saveScrollPosition();
+        this.root?.unmount();
+        this.root = null;
     }
 }

--- a/src/core/notes/calendar/Month.test.ts
+++ b/src/core/notes/calendar/Month.test.ts
@@ -1,0 +1,82 @@
+const mockEffects: Array<() => void | (() => void)> = [];
+const mockUseEffect = jest.fn((effect: () => void | (() => void)) => {
+  mockEffects.push(effect);
+});
+const mockUseRef = jest.fn(() => ({ current: null }));
+const mockUseState = jest.fn((initialValue: unknown) => [initialValue, jest.fn()]);
+
+jest.mock('react', () => ({
+  useEffect: mockUseEffect,
+  useRef: mockUseRef,
+  useState: mockUseState,
+}));
+
+import { useMonthLogic } from './Month';
+
+function createFakeApp() {
+  const vaultOn = jest.fn();
+  const vaultOff = jest.fn();
+  const metadataOn = jest.fn();
+  const metadataOff = jest.fn();
+
+  return {
+    app: {
+      vault: {
+        getMarkdownFiles: jest.fn().mockReturnValue([]),
+        on: vaultOn,
+        off: vaultOff,
+      },
+      metadataCache: {
+        getFileCache: jest.fn(),
+        on: metadataOn,
+        off: metadataOff,
+      },
+    },
+    vaultOn,
+    vaultOff,
+    metadataOn,
+    metadataOff,
+  };
+}
+
+describe('useMonthLogic listener lifecycle', () => {
+  beforeEach(() => {
+    mockEffects.length = 0;
+    mockUseEffect.mockClear();
+    mockUseRef.mockClear();
+    mockUseState.mockClear();
+  });
+
+  test('registers create, delete and changed once with one update callback', () => {
+    const { app, vaultOn, metadataOn } = createFakeApp();
+
+    useMonthLogic(app as any, 2026, 8);
+    mockEffects[0]();
+
+    expect(vaultOn).toHaveBeenCalledTimes(2);
+    expect(metadataOn).toHaveBeenCalledTimes(1);
+    expect(vaultOn).toHaveBeenNthCalledWith(1, 'create', expect.any(Function));
+    expect(vaultOn).toHaveBeenNthCalledWith(2, 'delete', expect.any(Function));
+    expect(metadataOn).toHaveBeenCalledWith('changed', expect.any(Function));
+
+    const createCallback = vaultOn.mock.calls[0][1];
+    expect(vaultOn.mock.calls[1][1]).toBe(createCallback);
+    expect(metadataOn.mock.calls[0][1]).toBe(createCallback);
+  });
+
+  test('returns cleanup that removes all listeners with their registered callback', () => {
+    const { app, vaultOn, vaultOff, metadataOn, metadataOff } = createFakeApp();
+
+    useMonthLogic(app as any, 2026, 8);
+    const cleanup = mockEffects[0]();
+
+    expect(cleanup).toEqual(expect.any(Function));
+    cleanup!();
+
+    expect(vaultOff).toHaveBeenCalledTimes(2);
+    expect(metadataOff).toHaveBeenCalledTimes(1);
+    expect(vaultOff).toHaveBeenNthCalledWith(1, 'create', vaultOn.mock.calls[0][1]);
+    expect(vaultOff).toHaveBeenNthCalledWith(2, 'delete', vaultOn.mock.calls[1][1]);
+    expect(metadataOff).toHaveBeenCalledWith('changed', metadataOn.mock.calls[0][1]);
+  });
+});


### PR DESCRIPTION
## Summary

- ties the React root to the CalendarView open/close lifecycle
- unmounts React when the Obsidian view closes
- creates a fresh root when the view is reopened
- preserves the existing scroll capture behavior
- adds characterization and regression coverage for CalendarView and Month listener cleanup

## Root cause

CalendarView created its React root in the constructor and kept it for the lifetime of the ItemView instance.

`onClose()` only saved the Bible scroll position and never unmounted React.

Month components already contain correct `useEffect` cleanup for their Vault and MetadataCache listeners, but those cleanups depend on React actually being unmounted.

## Fix

CalendarView now:

- starts with `root = null`
- creates the root during `onOpen()`
- renders only when a root exists
- saves scroll before closing
- unmounts the root during `onClose()`
- resets the root to `null`
- creates a fresh root on a later reopen

Two consecutive `onOpen()` calls without a close reuse the same active root.

## Validation

- 8 Jest suites passed
- 26 tests passed
- 0 expected failures
- 0 unexpected failures
- TypeScript check passed
- production build passed
- existing Month listener registration and cleanup behavior remains unchanged

## Scope

This PR intentionally does not:

- optimize Calendar listeners
- change CalendarYear or Month production logic
- change navigation
- change Obsidian leaf activation
- change Deferred View handling
- update dependencies or tooling
