### PR TITLE
fix: await Obsidian leaf lifecycle

### DIFF
--- a/src/adapters/Obsidian/MenuPrincipal.ts
+++ b/src/adapters/Obsidian/MenuPrincipal.ts
@@ -131,8 +131,9 @@ export class MenuPrincipal extends Menu {
     this.addMenuItem({
       title: "Refresh",
       icon: "calendar-check-2",
-      onClick: () => {
-        new Calendar(this.app); 
+      onClick: async () => {
+        const calendar = new Calendar(this.app);
+        await calendar.addCalendarView();
       }
     });
     

--- a/src/core/notes/calendar/Calendar.test.ts
+++ b/src/core/notes/calendar/Calendar.test.ts
@@ -1,0 +1,114 @@
+const CALENDAR_VIEW_TYPE = 'obsigen-calendar-view';
+
+jest.mock('./CalendarView', () => ({
+  CALENDAR_VIEW_TYPE,
+}));
+
+import { Calendar } from './Calendar';
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+
+  return { promise, resolve };
+}
+
+function createApp() {
+  return {
+    workspace: {
+      detachLeavesOfType: jest.fn(),
+      getRightLeaf: jest.fn(),
+      revealLeaf: jest.fn().mockResolvedValue(undefined),
+    },
+  };
+}
+
+function invokeAddCalendarView(app: ReturnType<typeof createApp>) {
+  const calendar = new Calendar(app as any);
+  return calendar.addCalendarView();
+}
+
+describe('Calendar leaf lifecycle', () => {
+  let consoleError: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  test('detaches existing leaves and requests an active Calendar view', async () => {
+    const app = createApp();
+    const leaf = {
+      setViewState: jest.fn().mockResolvedValue(undefined),
+    };
+    app.workspace.getRightLeaf.mockReturnValue(leaf);
+
+    await invokeAddCalendarView(app);
+
+    expect(app.workspace.detachLeavesOfType).toHaveBeenCalledWith(CALENDAR_VIEW_TYPE);
+    expect(app.workspace.getRightLeaf).toHaveBeenCalledWith(false);
+    expect(leaf.setViewState).toHaveBeenCalledWith({
+      type: CALENDAR_VIEW_TYPE,
+      active: true,
+    });
+    expect(app.workspace.revealLeaf).toHaveBeenCalledWith(leaf);
+  });
+
+  test('a null right leaf terminates safely', async () => {
+    const app = createApp();
+    app.workspace.getRightLeaf.mockReturnValue(null);
+
+    await expect(invokeAddCalendarView(app)).resolves.toBeUndefined();
+
+    expect(app.workspace.detachLeavesOfType).toHaveBeenCalledWith(CALENDAR_VIEW_TYPE);
+    expect(app.workspace.getRightLeaf).toHaveBeenCalledWith(false);
+    expect(app.workspace.revealLeaf).not.toHaveBeenCalled();
+  });
+
+  test('waits for setViewState before revealing the leaf', async () => {
+    const app = createApp();
+    const viewState = deferred();
+    const leaf = {
+      setViewState: jest.fn().mockReturnValue(viewState.promise),
+    };
+    app.workspace.getRightLeaf.mockReturnValue(leaf);
+
+    const completion = invokeAddCalendarView(app);
+    const revealCallsBeforeViewState = app.workspace.revealLeaf.mock.calls.length;
+    viewState.resolve();
+    await Promise.resolve(completion);
+
+    expect(revealCallsBeforeViewState).toBe(0);
+  });
+
+  test('does not complete until revealLeaf completes', async () => {
+    const app = createApp();
+    const reveal = deferred();
+    const leaf = {
+      setViewState: jest.fn().mockResolvedValue(undefined),
+    };
+    app.workspace.getRightLeaf.mockReturnValue(leaf);
+    app.workspace.revealLeaf.mockReturnValue(reveal.promise);
+
+    const operation = invokeAddCalendarView(app);
+    let completed = false;
+    const observedCompletion = operation.then(() => {
+      completed = true;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(app.workspace.revealLeaf).toHaveBeenCalledWith(leaf);
+    expect(completed).toBe(false);
+
+    reveal.resolve();
+    await observedCompletion;
+    expect(completed).toBe(true);
+  });
+});

--- a/src/core/notes/calendar/Calendar.ts
+++ b/src/core/notes/calendar/Calendar.ts
@@ -7,11 +7,9 @@ export class Calendar {
     constructor(app: App) {
 
         this.app = app;
-
-        this.addCalendarView();
     }
 
-    addCalendarView() {
+    async addCalendarView(): Promise<void> {
         this.app.workspace.detachLeavesOfType(CALENDAR_VIEW_TYPE);
     
         const leaf = this.app.workspace.getRightLeaf(false);
@@ -23,12 +21,12 @@ export class Calendar {
         }
     
         // Caso normal cuando 'leaf' no es null
-        leaf.setViewState({
+        await leaf.setViewState({
             type: CALENDAR_VIEW_TYPE,
             active: true,   
         });
     
-        this.app.workspace.revealLeaf(leaf);
+        await this.app.workspace.revealLeaf(leaf);
     }
     
 }

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,0 +1,232 @@
+const CALENDAR_VIEW_TYPE = 'obsigen-calendar-view';
+
+jest.mock('obsidian', () => ({
+  MarkdownView: class {},
+  Plugin: class {},
+}));
+
+jest.mock('src/adapters/Obsidian/MenuPrincipal', () => ({
+  MenuPrincipal: jest.fn(),
+}), { virtual: true });
+
+jest.mock('src/adapters/Obsidian/SampleModal', () => ({
+  SampleModal: jest.fn(),
+}), { virtual: true });
+
+jest.mock('src/adapters/Obsidian/SampleSettingTab', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}), { virtual: true });
+
+jest.mock('src/core/notes/calendar/CalendarView', () => ({
+  CALENDAR_VIEW_TYPE,
+  CalendarView: class {},
+}), { virtual: true });
+
+import MyPlugin from './main';
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+
+  return { promise, resolve };
+}
+
+function createWorkspace() {
+  return {
+    detachLeavesOfType: jest.fn(),
+    getLeavesOfType: jest.fn().mockReturnValue([]),
+    getRightLeaf: jest.fn(),
+    revealLeaf: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createPlugin(workspace: ReturnType<typeof createWorkspace>): MyPlugin {
+  const plugin = Object.create(MyPlugin.prototype) as MyPlugin;
+  (plugin as any).app = { workspace };
+  return plugin;
+}
+
+describe('MyPlugin leaf lifecycle', () => {
+  let consoleError: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  describe('onLayoutReady', () => {
+    test('an existing Calendar leaf short-circuits startup opening', async () => {
+      const workspace = createWorkspace();
+      const existingLeaf = {
+        setViewState: jest.fn(),
+      };
+      workspace.getLeavesOfType.mockReturnValue([existingLeaf]);
+      const plugin = createPlugin(workspace);
+
+      await plugin.onLayoutReady();
+
+      expect(workspace.getLeavesOfType).toHaveBeenCalledWith(CALENDAR_VIEW_TYPE);
+      expect(workspace.getRightLeaf).not.toHaveBeenCalled();
+      expect(existingLeaf.setViewState).not.toHaveBeenCalled();
+      expect(workspace.revealLeaf).not.toHaveBeenCalled();
+    });
+
+    test('a null right leaf terminates safely', async () => {
+      const workspace = createWorkspace();
+      workspace.getRightLeaf.mockReturnValue(null);
+      const plugin = createPlugin(workspace);
+
+      await expect(plugin.onLayoutReady()).resolves.toBeUndefined();
+
+      expect(workspace.getRightLeaf).toHaveBeenCalledWith(false);
+      expect(workspace.revealLeaf).not.toHaveBeenCalled();
+    });
+
+    test('requests the active Calendar view state', async () => {
+      const workspace = createWorkspace();
+      const leaf = {
+        setViewState: jest.fn().mockResolvedValue(undefined),
+        view: {},
+      };
+      workspace.getRightLeaf.mockReturnValue(leaf);
+      const plugin = createPlugin(workspace);
+
+      await plugin.onLayoutReady();
+
+      expect(leaf.setViewState).toHaveBeenCalledWith({
+        type: CALENDAR_VIEW_TYPE,
+        active: true,
+      });
+      expect(workspace.revealLeaf).toHaveBeenCalledWith(leaf);
+    });
+
+    test('waits for setViewState before revealing the leaf', async () => {
+      const workspace = createWorkspace();
+      const viewState = deferred();
+      const leaf = {
+        setViewState: jest.fn().mockReturnValue(viewState.promise),
+        view: {},
+      };
+      workspace.getRightLeaf.mockReturnValue(leaf);
+      const plugin = createPlugin(workspace);
+
+      const completion = plugin.onLayoutReady();
+      const revealCallsBeforeViewState = workspace.revealLeaf.mock.calls.length;
+      viewState.resolve();
+      await Promise.resolve(completion);
+
+      expect(revealCallsBeforeViewState).toBe(0);
+    });
+
+    test('does not complete until revealLeaf completes', async () => {
+      const workspace = createWorkspace();
+      const reveal = deferred();
+      const leaf = {
+        setViewState: jest.fn().mockResolvedValue(undefined),
+        view: {},
+      };
+      workspace.getRightLeaf.mockReturnValue(leaf);
+      workspace.revealLeaf.mockReturnValue(reveal.promise);
+      const plugin = createPlugin(workspace);
+
+      const completion = plugin.onLayoutReady();
+      let completed = false;
+      const observedCompletion = Promise.resolve(completion).then(() => {
+        completed = true;
+      });
+      await Promise.resolve();
+
+      expect(completed).toBe(false);
+
+      reveal.resolve();
+      await observedCompletion;
+    });
+
+    test('does not access leaf.view to configure and reveal Calendar', async () => {
+      const workspace = createWorkspace();
+      let viewAccesses = 0;
+      const leaf = {
+        setViewState: jest.fn().mockResolvedValue(undefined),
+        get view() {
+          viewAccesses += 1;
+          return {};
+        },
+      };
+      workspace.getRightLeaf.mockReturnValue(leaf);
+      const plugin = createPlugin(workspace);
+
+      await plugin.onLayoutReady();
+
+      expect(viewAccesses).toBe(0);
+    });
+  });
+
+  describe('activateView', () => {
+    test('detaches existing leaves and terminates safely for a null right leaf', async () => {
+      const workspace = createWorkspace();
+      workspace.getRightLeaf.mockReturnValue(null);
+      const plugin = createPlugin(workspace);
+
+      await expect(plugin.activateView()).resolves.toBeUndefined();
+
+      expect(workspace.detachLeavesOfType).toHaveBeenCalledWith(CALENDAR_VIEW_TYPE);
+      expect(workspace.getRightLeaf).toHaveBeenCalledWith(false);
+      expect(workspace.revealLeaf).not.toHaveBeenCalled();
+    });
+
+    test('waits for the requested view state before revealing the leaf', async () => {
+      const workspace = createWorkspace();
+      const viewState = deferred();
+      const leaf = {
+        setViewState: jest.fn().mockReturnValue(viewState.promise),
+      };
+      workspace.getRightLeaf.mockReturnValue(leaf);
+      const plugin = createPlugin(workspace);
+
+      const completion = plugin.activateView();
+
+      expect(leaf.setViewState).toHaveBeenCalledWith({
+        type: CALENDAR_VIEW_TYPE,
+        active: true,
+      });
+      expect(workspace.revealLeaf).not.toHaveBeenCalled();
+
+      viewState.resolve();
+      await completion;
+
+      expect(workspace.revealLeaf).toHaveBeenCalledWith(leaf);
+    });
+
+    test('does not complete until revealLeaf completes', async () => {
+      const workspace = createWorkspace();
+      const reveal = deferred();
+      const leaf = {
+        setViewState: jest.fn().mockResolvedValue(undefined),
+      };
+      workspace.getRightLeaf.mockReturnValue(leaf);
+      workspace.revealLeaf.mockReturnValue(reveal.promise);
+      const plugin = createPlugin(workspace);
+
+      const completion = plugin.activateView();
+      let completed = false;
+      const observedCompletion = completion.then(() => {
+        completed = true;
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(workspace.revealLeaf).toHaveBeenCalledWith(leaf);
+      expect(completed).toBe(false);
+
+      reveal.resolve();
+      await observedCompletion;
+    });
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,6 @@ const DEFAULT_SETTINGS: MyPluginSettings = {
 
 export default class MyPlugin extends Plugin {
 	settings: MyPluginSettings;
-	private view: CalendarView;
 
 	async onload() {
 		console.log("Loading Obsigen plugin");
@@ -95,7 +94,7 @@ export default class MyPlugin extends Plugin {
 		await this.saveData(this.settings);
 	}
 
-	onLayoutReady(): void {
+	async onLayoutReady(): Promise<void> {
 		if (this.app.workspace.getLeavesOfType(CALENDAR_VIEW_TYPE).length > 0) {
 			return;
 		}
@@ -107,14 +106,13 @@ export default class MyPlugin extends Plugin {
 			return;
 		}
 
-		rightLeaf.setViewState({
+		await rightLeaf.setViewState({
 			type: CALENDAR_VIEW_TYPE,
 			active: true, // Marcamos la vista como activa.
 		});
 
 		// Aseguramos que el leaf se revele para el usuario.
-		this.app.workspace.revealLeaf(rightLeaf);
-		this.view = rightLeaf.view as CalendarView;
+		await this.app.workspace.revealLeaf(rightLeaf);
 	}
 
 	async activateView() {
@@ -137,6 +135,6 @@ export default class MyPlugin extends Plugin {
 		});
 
 		// Utilizamos revealLeaf para asegurarnos de que la vista se muestre al usuario.
-		this.app.workspace.revealLeaf(rightLeaf);
+		await this.app.workspace.revealLeaf(rightLeaf);
 	}
 }


### PR DESCRIPTION
## Summary

- awaits Obsidian view-state changes before revealing the Calendar leaf
- awaits `revealLeaf` before startup/activation operations complete
- removes the unused direct access to `WorkspaceLeaf.view`
- makes Calendar refresh an explicit awaitable operation
- removes the async side effect from the Calendar constructor
- adds regression coverage for startup, activation and refresh lifecycle

## Root cause

Obsigen had several workspace operations that were started without awaiting their completion.

Startup called both `setViewState` and `revealLeaf` without awaiting either operation and then immediately accessed `leaf.view`.

The Calendar Refresh flow also launched both operations from a constructor side effect.

This could race with Obsidian's workspace lifecycle and with Deferred Views.

## Fix

Startup now:

1. checks for an existing Calendar leaf
2. gets the right leaf
3. awaits `setViewState`
4. awaits `revealLeaf`
5. completes without accessing `leaf.view`

`activateView` now also awaits `revealLeaf`.

Calendar refresh now:

1. creates a Calendar helper without side effects
2. explicitly awaits `addCalendarView`
3. detaches existing Calendar leaves
4. awaits `setViewState`
5. awaits `revealLeaf`

No `loadIfDeferred`, `instanceof CalendarView`, or new workspace abstraction was introduced.

## Validation

- 10 Jest suites passed
- 39 tests passed
- 0 expected failures
- 0 unexpected failures
- TypeScript check passed
- production build passed
- Calendar and Bible smoke-tested successfully in Obsidian

## Scope

This PR intentionally does not:

- change CalendarView React lifecycle
- optimize Calendar listeners
- change Month production logic
- modify Bible or Timeline
- modify note navigation
- update Obsidian or other dependencies
- introduce a shared workspace adapter
