### PR TITLE
fix: correct CalendarEvent lifecycle and dates

### DIFF
--- a/src/core/notes/calendar/CalendarEvent.test.ts
+++ b/src/core/notes/calendar/CalendarEvent.test.ts
@@ -1,0 +1,285 @@
+const mockNotice = jest.fn();
+const mockCreateNote = jest.fn();
+const mockMomento = jest.fn().mockImplementation(() => ({
+  createNote: mockCreateNote,
+}));
+
+jest.mock('obsidian', () => ({
+  ButtonComponent: class {},
+  DropdownComponent: class {},
+  Modal: class {},
+  Notice: mockNotice,
+  TextAreaComponent: class {},
+  TextComponent: class {},
+  TFile: class {},
+}));
+
+jest.mock('./../../notes/momento/Momento', () => ({
+  Momento: mockMomento,
+}));
+
+jest.mock('./CalendarIcon', () => ({ iconData: {} }));
+jest.mock('./CalendarIconPicker', () => ({ CalendarIconPicker: () => null }));
+jest.mock('./NoteSelector', () => ({ NoteSelector: () => null }));
+
+import { CalendarEvent, FormValues } from './CalendarEvent';
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+function field(value: string) {
+  return {
+    getValue: jest.fn().mockReturnValue(value),
+    setValue: jest.fn(),
+  };
+}
+
+function createBareEvent(): CalendarEvent {
+  const event = Object.create(CalendarEvent.prototype) as CalendarEvent;
+  Object.assign(event as any, {
+    app: {},
+    close: jest.fn(),
+    open: jest.fn(),
+    submitted: false,
+  });
+  return event;
+}
+
+function dateFromFields({
+  year,
+  era = 'DC',
+  month = '01',
+  day = '01',
+  hour = '00',
+  minute = '00',
+}: {
+  year: string;
+  era?: 'AC' | 'DC';
+  month?: string;
+  day?: string;
+  hour?: string;
+  minute?: string;
+}): Date {
+  const event = createBareEvent();
+
+  return (event as any).getDateFromFields(
+    field(year),
+    field(era),
+    field(month),
+    field(day),
+    field(hour),
+    field(minute),
+  );
+}
+
+function createFormValues(): FormValues {
+  const date = new Date(2024, 1, 29, 12, 30, 0);
+
+  return {
+    title: 'Sample event',
+    urls: '',
+    description: 'Description',
+    date,
+    endDate: new Date(date.getTime()),
+    selectedIcon: 'default-icon',
+    locations: '',
+    type: 'Moment',
+    tags: 'calendar',
+  };
+}
+
+function prepareSubmission(event: CalendarEvent, values = createFormValues()) {
+  (event as any).getFormValues = jest.fn().mockReturnValue(values);
+  (event as any).validateForm = jest.fn().mockReturnValue(null);
+  return values;
+}
+
+describe('CalendarEvent correctness', () => {
+  beforeEach(() => {
+    mockNotice.mockClear();
+    mockCreateNote.mockReset();
+    mockMomento.mockClear();
+  });
+
+  describe('date construction', () => {
+    test('preserves a valid modern leap-day date and time', () => {
+      const date = dateFromFields({
+        year: '2024',
+        month: '02',
+        day: '29',
+        hour: '12',
+        minute: '30',
+      });
+
+      expect(date.getFullYear()).toBe(2024);
+      expect(date.getMonth()).toBe(1);
+      expect(date.getDate()).toBe(29);
+      expect(date.getHours()).toBe(12);
+      expect(date.getMinutes()).toBe(30);
+    });
+
+    test('preserves DC year 100', () => {
+      const date = dateFromFields({ year: '0100' });
+
+      expect(date.getFullYear()).toBe(100);
+    });
+
+    test.each([
+      ['0001', 1],
+      ['0005', 5],
+      ['0099', 99],
+    ])('preserves DC year %s as year %i', (year, expectedYear) => {
+      const date = dateFromFields({ year });
+
+      expect(date.getFullYear()).toBe(expectedYear);
+    });
+
+    test('preserves the current AC representation as a negative year', () => {
+      const date = dateFromFields({ year: '0005', era: 'AC' });
+
+      expect(date.getFullYear()).toBe(-5);
+    });
+
+    test.each([
+      ['2023-02-29', { year: '2023', month: '02', day: '29' }],
+      ['2024-04-31', { year: '2024', month: '04', day: '31' }],
+    ])('rejects the impossible date %s', (_label, input) => {
+      expect(() => dateFromFields(input)).toThrow();
+    });
+
+    test.each(['DC', 'AC'] as const)('rejects year zero in era %s', (era) => {
+      expect(() => dateFromFields({ year: '0000', era })).toThrow();
+    });
+  });
+
+  describe('cancellation', () => {
+    test('emits the existing cancellation Notice', () => {
+      const event = createBareEvent();
+      event.openModal();
+
+      event.onClose();
+
+      expect(mockNotice).toHaveBeenCalledWith('Cancelled prompt');
+    });
+
+    test('settles the modal operation when closed without submit', async () => {
+      const event = createBareEvent();
+      const operation = event.openModal();
+
+      event.onClose();
+
+      await expect(operation).resolves.toBeNull();
+    });
+  });
+
+  describe('submission', () => {
+    test('waits for createNote before completing the modal operation', async () => {
+      const event = createBareEvent();
+      const values = prepareSubmission(event);
+      const noteCreation = deferred();
+      mockCreateNote.mockReturnValue(noteCreation.promise);
+      const operation = event.openModal();
+      let completed = false;
+      operation.then(() => { completed = true; });
+
+      const submission = (event as any).onSubmit({ preventDefault: jest.fn() });
+      await Promise.resolve();
+
+      expect(completed).toBe(false);
+
+      noteCreation.resolve();
+      await submission;
+
+      expect(mockMomento).toHaveBeenCalledWith(values.date, values.endDate);
+      expect(mockCreateNote).toHaveBeenCalledTimes(1);
+      await expect(operation).resolves.toBe(values);
+      expect((event as any).close).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not report success when createNote rejects', async () => {
+      const event = createBareEvent();
+      const error = new Error('note creation failed');
+      prepareSubmission(event);
+      const noteCreation = deferred();
+      mockCreateNote.mockReturnValue(noteCreation.promise);
+      const operation = event.openModal();
+
+      const submission = (event as any).onSubmit({ preventDefault: jest.fn() });
+      noteCreation.reject(error);
+
+      await expect(operation).rejects.toBe(error);
+      await submission;
+      expect((event as any).close).toHaveBeenCalledTimes(1);
+
+      event.onClose();
+      expect(mockNotice).not.toHaveBeenCalledWith('Cancelled prompt');
+    });
+
+    test('validation failure emits Notice, clears submitted and closes', async () => {
+      const event = createBareEvent();
+      const values = prepareSubmission(event);
+      (event as any).validateForm.mockReturnValue('Invalid date range');
+      const operation = event.openModal();
+
+      await (event as any).onSubmit({ preventDefault: jest.fn() });
+      event.onClose();
+
+      expect((event as any).getFormValues).toHaveBeenCalledTimes(1);
+      expect((event as any).validateForm).toHaveBeenCalledWith(values);
+      expect(mockNotice).toHaveBeenCalledWith('Invalid date range');
+      expect((event as any).submitted).toBe(false);
+      expect((event as any).close).toHaveBeenCalledTimes(1);
+      expect(mockCreateNote).not.toHaveBeenCalled();
+      await expect(operation).resolves.toBeNull();
+    });
+
+    test('field parsing errors emit Notice and settle as cancellation', async () => {
+      const event = createBareEvent();
+      (event as any).getFormValues = jest.fn().mockImplementation(() => {
+        throw new Error('Invalid date component values');
+      });
+      const operation = event.openModal();
+
+      await (event as any).onSubmit({ preventDefault: jest.fn() });
+      event.onClose();
+
+      expect(mockNotice).toHaveBeenCalledWith('Invalid date component values');
+      expect((event as any).submitted).toBe(false);
+      expect((event as any).close).toHaveBeenCalledTimes(1);
+      await expect(operation).resolves.toBeNull();
+    });
+  });
+
+  describe('interactive date synchronization', () => {
+    test('temporarily invalid dates do not escape from syncEndDate', () => {
+      const event = createBareEvent();
+      const endYearField = field('2024');
+      Object.assign(event as any, {
+        yearField: field('2024'),
+        eraField: field('DC'),
+        monthDropdown: field('02'),
+        dayDropdown: field('31'),
+        hourDropdown: field('12'),
+        minuteDropdown: field('30'),
+        endYearField,
+        endEraField: field('DC'),
+        endMonthDropdown: field('02'),
+        endDayDropdown: field('29'),
+        endHourDropdown: field('12'),
+        endMinuteDropdown: field('30'),
+      });
+
+      expect(() => (event as any).syncEndDate()).not.toThrow();
+      expect(endYearField.setValue).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/core/notes/calendar/CalendarEvent.ts
+++ b/src/core/notes/calendar/CalendarEvent.ts
@@ -28,8 +28,8 @@ export interface FormValues {
 }
 
 export class CalendarEvent extends Modal {
-    private resolve!: (value: FormValues) => void;
-    private reject!: (reason?: TemplaterError) => void;
+    private resolve!: (value: FormValues | null) => void;
+    private reject!: (reason?: unknown) => void;
     private submitted = false;
 
     private yearField!: TextComponent;
@@ -72,6 +72,7 @@ export class CalendarEvent extends Modal {
     onClose(): void {
         if (!this.submitted) {
             new Notice("Cancelled prompt");
+            this.resolve(null);
         }
     }
 
@@ -259,12 +260,24 @@ export class CalendarEvent extends Modal {
         const minute = parseInt(minuteDropdown.getValue().padStart(2, "0"));
     
         // Aseguramos que los valores son válidos antes de crear la fecha
-        if (isNaN(yearValue) || isNaN(month) || isNaN(day) || isNaN(hour) || isNaN(minute)) {
+        if (isNaN(yearValue) || isNaN(month) || isNaN(day) || isNaN(hour) || isNaN(minute) || yearValue === 0) {
             throw new Error("Invalid date component values");
         }
     
         // Crear la fecha usando la hora y la zona horaria tal como se selecciona en el formulario
-        const date = new Date(yearValue, month, day, hour, minute, 0);
+        const date = new Date(0);
+        date.setFullYear(yearValue, month, day);
+        date.setHours(hour, minute, 0, 0);
+
+        if (
+            date.getFullYear() !== yearValue ||
+            date.getMonth() !== month ||
+            date.getDate() !== day ||
+            date.getHours() !== hour ||
+            date.getMinutes() !== minute
+        ) {
+            throw new Error("Invalid date component values");
+        }
     
         return date;
     }
@@ -281,19 +294,27 @@ export class CalendarEvent extends Modal {
         return year.toString().padStart(4, "0");
     }
 
-    openModal(): Promise<FormValues> {
-        return new Promise<FormValues>((resolve, reject) => {
+    openModal(): Promise<FormValues | null> {
+        return new Promise<FormValues | null>((resolve, reject) => {
             this.resolve = resolve;
             this.reject = reject;
             this.open();
         });
     }
 
-    private onSubmit(evt: Event) {
+    private async onSubmit(evt: Event): Promise<void> {
         evt.preventDefault();
-        this.submitted = true;
 
-        const formValues = this.getFormValues();
+        let formValues: FormValues;
+        try {
+            formValues = this.getFormValues();
+        } catch (error) {
+            new Notice(error instanceof Error ? error.message : String(error));
+            this.submitted = false;
+            this.close();
+            return;
+        }
+
         const validationError = this.validateForm(formValues);
         if (validationError) {
             new Notice(validationError);
@@ -302,21 +323,27 @@ export class CalendarEvent extends Modal {
             return;
         }
 
-        this.resolve(formValues);
+        this.submitted = true;
 
-        new Momento(formValues.date, formValues.endDate).createNote(
-            formValues.type,
-            this.app,
-            formValues.title,
-            formValues.description,
-            formValues.selectedIcon,
-            "description",
-            formValues.locations,
-            formValues.urls,
-            formValues.tags
-        );
+        try {
+            await new Momento(formValues.date, formValues.endDate).createNote(
+                formValues.type,
+                this.app,
+                formValues.title,
+                formValues.description,
+                formValues.selectedIcon,
+                "description",
+                formValues.locations,
+                formValues.urls,
+                formValues.tags
+            );
 
-        this.close();
+            this.resolve(formValues);
+        } catch (error) {
+            this.reject(error);
+        } finally {
+            this.close();
+        }
     }
 
     private getFormValues(): FormValues {
@@ -352,8 +379,15 @@ export class CalendarEvent extends Modal {
     }
 
     private syncEndDate() {
-        const startDate = this.getDateFromFields(this.yearField, this.eraField, this.monthDropdown, this.dayDropdown, this.hourDropdown, this.minuteDropdown);
-        const endDate = this.getDateFromFields(this.endYearField, this.endEraField, this.endMonthDropdown, this.endDayDropdown, this.endHourDropdown, this.endMinuteDropdown);
+        let startDate: Date;
+        let endDate: Date;
+
+        try {
+            startDate = this.getDateFromFields(this.yearField, this.eraField, this.monthDropdown, this.dayDropdown, this.hourDropdown, this.minuteDropdown);
+            endDate = this.getDateFromFields(this.endYearField, this.endEraField, this.endMonthDropdown, this.endDayDropdown, this.endHourDropdown, this.endMinuteDropdown);
+        } catch {
+            return;
+        }
     
         // Si la fecha final es anterior a la fecha inicial, ajustar la fecha final para que coincida con la fecha inicial
         if (endDate < startDate) {
@@ -365,12 +399,4 @@ export class CalendarEvent extends Modal {
             this.endMinuteDropdown.setValue(this.minuteDropdown.getValue());
         }
     }    
-}
-
-class TemplaterError extends Error {
-    constructor(msg: string, public console_msg?: string) {
-        super(msg);
-        this.name = this.constructor.name;
-        Error.captureStackTrace(this, this.constructor);
-    }
 }


### PR DESCRIPTION
## Summary

- settles CalendarEvent cancellation instead of leaving the modal Promise pending
- waits for note creation before reporting successful submission
- propagates note-creation failures through the modal operation
- preserves literal AD years 1–99 instead of shifting them into 1901–1999
- rejects impossible calendar dates instead of accepting JavaScript date normalization
- rejects year zero for the existing BC/AD model
- keeps interactive end-date synchronization safe while fields are temporarily invalid

## Root causes

CalendarEvent had three independent correctness issues:

1. Closing without submit displayed a cancellation Notice but never resolved or rejected `openModal()`.
2. Submission resolved the modal operation before awaiting `Momento.createNote()`.
3. Date construction used the multi-argument JavaScript `Date` constructor, which treats years 0–99 specially and silently normalizes impossible dates.

## Fix

Cancellation now resolves:

`null`

and `openModal()` returns:

`Promise<FormValues | null>`.

Submission now:

1. validates the form
2. marks the operation as submitted
3. awaits `Momento.createNote()`
4. resolves only after successful note creation
5. rejects with the original error if note creation fails
6. closes the modal safely

Dates are constructed using an explicit full-year assignment and verified component-by-component to reject normalization.

## Date contracts

- 0001 AD → year 1
- 0005 AD → year 5
- 0099 AD → year 99
- 0100 AD → year 100
- 0005 BC → year -5
- year 0000 → rejected
- 2024-02-29 → valid
- 2023-02-29 → rejected
- 2024-04-31 → rejected

## Validation

- 11 Jest suites passed
- 56 tests passed
- 0 expected failures
- 0 unexpected failures
- TypeScript check passed
- production build passed
- manual validation in Obsidian passed

## Scope

This PR intentionally does not:

- change CalendarEvent UI
- change Calendar, Bible or Timeline
- change Momento or NoteGenerator
- change embedded React-root lifecycle
- clean up CalendarEvent field typing
- update dependencies or tooling
