### PR TITLE
perf: optimize Bible chapter hydration

### DIFF
--- a/src/core/notes/bible/BibleViewChapters.test.ts
+++ b/src/core/notes/bible/BibleViewChapters.test.ts
@@ -1,0 +1,412 @@
+import {
+  fetchChapterNotes,
+  getChapterNotes,
+  openLocationNote,
+  openNote,
+} from "./BibleViewChapters";
+import { bibleStructure } from "./BibleViewStructure";
+import { openVaultNote } from "../../../adapters/Obsidian/openVaultNote";
+
+jest.mock("../../../adapters/Obsidian/openVaultNote", () => ({
+  openVaultNote: jest.fn().mockResolvedValue(undefined),
+}));
+
+interface FixtureFile {
+  path: string;
+  basename: string;
+}
+
+const TOTAL_BOOKS = Object.keys(bibleStructure).length;
+const TOTAL_CHAPTERS = Object.values(bibleStructure).reduce(
+  (total, book) => total + Object.keys(book.chapters).length,
+  0,
+);
+
+const mockOpenVaultNote = jest.mocked(openVaultNote);
+
+type LocationMode = "none" | "single" | "multiple";
+
+function createBibleFixture(locationMode: LocationMode = "none") {
+  const files: FixtureFile[] = [
+    {
+      path: "333 Biblia/San Juan/1/Jn 1, 10-15 La Palabra se hizo carne.md",
+      basename: "Jn 1, 10-15 La Palabra se hizo carne",
+    },
+    {
+      path: "333 Biblia/San Juan/1/Jn 1, 1-5 En el principio.md",
+      basename: "Jn 1, 1-5 En el principio",
+    },
+    {
+      path: "333 Biblia/San Juan/1/Jn 1, 6-9 Testimonio de Juan.md",
+      basename: "Jn 1, 6-9 Testimonio de Juan",
+    },
+    {
+      path: "333 Biblia/Salmos/Sal 1,1-6 Los dos caminos.md",
+      basename: "Sal 1,1-6 Los dos caminos",
+    },
+    {
+      path: "300 Lugares/Atlas Roma histórico.md",
+      basename: "Atlas Roma histórico",
+    },
+    {
+      path: "300 Lugares/Roma.md",
+      basename: "Roma",
+    },
+    {
+      path: "300 Lugares/Mapa Jerusalén antiguo.md",
+      basename: "Mapa Jerusalén antiguo",
+    },
+    {
+      path: "300 Lugares/Comarca de Nazaret.md",
+      basename: "Comarca de Nazaret",
+    },
+    {
+      path: "999 Fuera de la Biblia/Nota sin relación.md",
+      basename: "Nota sin relación",
+    },
+  ];
+
+  const frontmatterByPath = new Map<string, Record<string, unknown>>([
+    [
+      files[0].path,
+      {
+        verse_passage: "Jn 1, 10-15",
+        verse_title: "La Palabra se hizo carne",
+        rating: 5,
+        cover: "covers/incarnation.jpg",
+        locations: locationMode === "multiple" ? ["[[Roma]]"] : [],
+      },
+    ],
+    [
+      files[1].path,
+      {
+        verse_passage: "Jn 1, 1-5",
+        verse_title: "En el principio",
+        rating: 4,
+        locations: locationMode === "multiple" ? ["[[Nazaret]]"] : [],
+      },
+    ],
+    [
+      files[2].path,
+      {
+        verse_passage: "Jn 1, 6-9",
+        verse_title: "Testimonio de Juan",
+        rating: 3,
+        cover: "covers/testimony.jpg",
+        locations:
+          locationMode === "single" || locationMode === "multiple"
+            ? ["[[lugar-inexistente|Jerusalén]]"]
+            : [],
+      },
+    ],
+    [
+      files[3].path,
+      {
+        verse_title: "Los dos caminos",
+        rating: 5,
+      },
+    ],
+    [files[4].path, { location: [41.9, 12.5] }],
+    [files[5].path, { location: [0, 0] }],
+    [files[6].path, { location: [31.778, 35.235] }],
+    [files[7].path, { location: [32.7, 35.3] }],
+    [files[8].path, {}],
+  ]);
+
+  const originalIterator = files[Symbol.iterator].bind(files);
+  const iteratorSpy = jest
+    .spyOn(files, Symbol.iterator)
+    .mockImplementation(() => originalIterator());
+  const originalFilter = files.filter.bind(files);
+  const filterSpy = jest
+    .spyOn(files, "filter")
+    .mockImplementation(
+      ((callback: Parameters<typeof files.filter>[0], thisArg?: unknown) =>
+        originalFilter(callback, thisArg)) as typeof files.filter,
+    );
+
+  const getFiles = jest.fn(() => files);
+  const getAbstractFileByPath = jest.fn((path: string) =>
+    files.find((file) => file.path === path),
+  );
+  const getFileCache = jest.fn((file: FixtureFile) => ({
+    frontmatter: frontmatterByPath.get(file.path),
+  }));
+  const getResourcePath = jest.fn((path: string) => `resource:${path}`);
+
+  const app = {
+    vault: {
+      getFiles,
+      getAbstractFileByPath,
+      adapter: { getResourcePath },
+    },
+    metadataCache: { getFileCache },
+  } as never;
+
+  return {
+    app,
+    files,
+    filterSpy,
+    frontmatterByPath,
+    getAbstractFileByPath,
+    getFileCache,
+    getFiles,
+    getResourcePath,
+    iteratorSpy,
+  };
+}
+
+describe("BibleViewChapters characterization", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("records the complete Bible structure traversed by hydration", () => {
+    expect(TOTAL_BOOKS).toBe(46);
+    expect(TOTAL_CHAPTERS).toBe(1088);
+    expect(Object.keys(bibleStructure["San Juan"].chapters)).toHaveLength(21);
+    expect(Object.keys(bibleStructure.Salmos.chapters)).toHaveLength(150);
+  });
+
+  it("maps and sorts a regular chapter while ignoring unrelated files", async () => {
+    const fixture = createBibleFixture("single");
+
+    const notes = await getChapterNotes(fixture.app, "San Juan", "1");
+
+    expect(notes.map((note) => note.verseRange)).toEqual([
+      [1, 5],
+      [6, 9],
+      [10, 15],
+    ]);
+    expect(notes[1]).toEqual(expect.objectContaining({
+      path: "333 Biblia/San Juan/1/Jn 1, 6-9 Testimonio de Juan.md",
+      verseRange: [6, 9],
+      title: "Testimonio de Juan",
+      rating: 3,
+      verse_title: "Testimonio de Juan",
+      cover: "resource:covers/testimony.jpg",
+      locations: ["[[lugar-inexistente|Jerusalén]]"],
+      coordinates: [31.778, 35.235],
+    }));
+    expect(fixture.getFiles).toHaveBeenCalledTimes(2);
+    expect(fixture.filterSpy).toHaveBeenCalledTimes(2);
+    expect(fixture.getAbstractFileByPath).toHaveBeenCalledTimes(3);
+    expect(fixture.getFileCache).toHaveBeenCalledTimes(4);
+  });
+
+  it("uses the Psalm filename fallback and the flat Salmos folder", async () => {
+    const fixture = createBibleFixture();
+
+    const notes = await getChapterNotes(fixture.app, "Salmos", "1");
+
+    expect(notes).toEqual([
+      expect.objectContaining({
+        path: "333 Biblia/Salmos/Sal 1,1-6 Los dos caminos.md",
+        verseRange: [1, 6],
+        title: "Los dos caminos",
+        rating: 5,
+        verse_title: "Los dos caminos",
+        cover: "",
+        locations: [],
+        coordinates: null,
+      }),
+    ]);
+    expect(fixture.getFiles).toHaveBeenCalledTimes(1);
+    expect(fixture.filterSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns an empty array for a chapter without matching notes", async () => {
+    const fixture = createBibleFixture();
+
+    await expect(getChapterNotes(fixture.app, "San Juan", "2")).resolves.toEqual(
+      [],
+    );
+    expect(fixture.getFiles).toHaveBeenCalledTimes(1);
+    expect(fixture.filterSpy).toHaveBeenCalledTimes(1);
+    expect(fixture.getFileCache).not.toHaveBeenCalled();
+  });
+
+  it("returns one keyed array for every chapter in BibleViewStructure", async () => {
+    const fixture = createBibleFixture();
+
+    const result = await fetchChapterNotes(fixture.app);
+
+    expect(Object.keys(result)).toHaveLength(TOTAL_CHAPTERS);
+    expect(result["San Juan-1"]).toHaveLength(3);
+    expect(result["San Juan-2"]).toEqual([]);
+    expect(result["Salmos-1"]).toHaveLength(1);
+  });
+
+  describe("current full hydration cost", () => {
+    it("uses one snapshot traversal when no note has locations", async () => {
+      const fixture = createBibleFixture();
+
+      await fetchChapterNotes(fixture.app);
+
+      expect(fixture.getFiles).toHaveBeenCalledTimes(1);
+      expect(fixture.filterSpy).not.toHaveBeenCalled();
+      expect(fixture.iteratorSpy).toHaveBeenCalledTimes(1);
+      expect(fixture.getAbstractFileByPath).toHaveBeenCalledTimes(4);
+      expect(fixture.getFileCache).toHaveBeenCalledTimes(4);
+    });
+
+    it("resolves one location with one additional bounded traversal", async () => {
+      const fixture = createBibleFixture("single");
+
+      await fetchChapterNotes(fixture.app);
+
+      expect(fixture.getFiles).toHaveBeenCalledTimes(1);
+      expect(fixture.filterSpy).not.toHaveBeenCalled();
+      expect(fixture.iteratorSpy).toHaveBeenCalledTimes(2);
+      expect(fixture.getAbstractFileByPath).toHaveBeenCalledTimes(4);
+      expect(fixture.getFileCache).toHaveBeenCalledTimes(5);
+    });
+  });
+
+  describe("hydration performance contracts", () => {
+    it("takes one vault snapshot per full hydration", async () => {
+      const fixture = createBibleFixture("single");
+
+      await fetchChapterNotes(fixture.app);
+
+      expect(fixture.getFiles).toHaveBeenCalledTimes(1);
+    });
+
+    it("uses at most two full-vault traversals per full hydration", async () => {
+      const fixture = createBibleFixture("single");
+
+      await fetchChapterNotes(fixture.app);
+
+      const fullVaultTraversals =
+        fixture.filterSpy.mock.calls.length +
+        fixture.iteratorSpy.mock.calls.length;
+      expect(fullVaultTraversals).toBeLessThanOrEqual(2);
+    });
+
+    it("resolves three distinct locations without additional snapshots or traversals", async () => {
+      const fixture = createBibleFixture("multiple");
+
+      const result = await fetchChapterNotes(fixture.app);
+
+      expect(fixture.getFiles).toHaveBeenCalledTimes(1);
+      expect(fixture.filterSpy).not.toHaveBeenCalled();
+      expect(fixture.iteratorSpy).toHaveBeenCalledTimes(2);
+      expect(result["San Juan-1"].map((note) => note.coordinates)).toEqual([
+        [32.7, 35.3],
+        [31.778, 35.235],
+        [41.9, 12.5],
+      ]);
+      expect(fixture.getAbstractFileByPath).toHaveBeenCalledTimes(4);
+      expect(fixture.getFileCache).toHaveBeenCalledTimes(7);
+    });
+
+    it("takes a fresh snapshot on each invocation", async () => {
+      const fixture = createBibleFixture();
+      const addedFile: FixtureFile = {
+        path: "333 Biblia/San Juan/2/Jn 2, 1-5 Las bodas de Caná.md",
+        basename: "Jn 2, 1-5 Las bodas de Caná",
+      };
+      const secondSnapshot = [...fixture.files, addedFile];
+      fixture.frontmatterByPath.set(addedFile.path, {
+        verse_passage: "Jn 2, 1-5",
+        verse_title: "Las bodas de Caná",
+        rating: 5,
+      });
+      fixture.getFiles
+        .mockReturnValueOnce(fixture.files as never)
+        .mockReturnValueOnce(secondSnapshot as never);
+      fixture.getAbstractFileByPath.mockImplementation((path: string) =>
+        secondSnapshot.find((file) => file.path === path),
+      );
+
+      const firstResult = await fetchChapterNotes(fixture.app);
+      const secondResult = await fetchChapterNotes(fixture.app);
+
+      expect(fixture.getFiles).toHaveBeenCalledTimes(2);
+      expect(firstResult["San Juan-2"]).toEqual([]);
+      expect(secondResult["San Juan-2"]).toEqual([
+        expect.objectContaining({
+          path: addedFile.path,
+          verseRange: [1, 5],
+          title: "Las bodas de Caná",
+        }),
+      ]);
+    });
+  });
+
+  describe("transient Bible index regressions", () => {
+    it("keeps notes nested below a regular chapter folder", async () => {
+      const fixture = createBibleFixture();
+      const nestedFile: FixtureFile = {
+        path: "333 Biblia/San Juan/2/comentarios/Jn 2, 6-8 Nota anidada.md",
+        basename: "Jn 2, 6-8 Nota anidada",
+      };
+      fixture.files.push(nestedFile);
+      fixture.frontmatterByPath.set(nestedFile.path, {
+        verse_passage: "Jn 2, 6-8",
+        verse_title: "Nota anidada",
+      });
+
+      const result = await fetchChapterNotes(fixture.app);
+
+      expect(result["San Juan-2"]).toEqual([
+        expect.objectContaining({ path: nestedFile.path }),
+      ]);
+    });
+
+    it("keeps the first matching Psalm in snapshot order", async () => {
+      const fixture = createBibleFixture();
+      const duplicatePsalm: FixtureFile = {
+        path: "333 Biblia/Salmos/duplicados/Sal 1,7-9 Otro candidato.md",
+        basename: "Sal 1,7-9 Otro candidato",
+      };
+      fixture.files.push(duplicatePsalm);
+      fixture.frontmatterByPath.set(duplicatePsalm.path, {
+        verse_title: "Otro candidato",
+      });
+
+      const result = await fetchChapterNotes(fixture.app);
+
+      expect(result["Salmos-1"]).toEqual([
+        expect.objectContaining({
+          path: "333 Biblia/Salmos/Sal 1,1-6 Los dos caminos.md",
+        }),
+      ]);
+    });
+  });
+
+  describe("interactive note opening", () => {
+    it("rescans the vault before opening a verse note", async () => {
+      const fixture = createBibleFixture();
+
+      await openNote(fixture.app, "San Juan", "1", [1, 5]);
+
+      expect(fixture.getFiles).toHaveBeenCalledTimes(1);
+      expect(fixture.filterSpy).toHaveBeenCalledTimes(1);
+      expect(mockOpenVaultNote).toHaveBeenCalledWith(
+        fixture.app,
+        expect.objectContaining({
+          path: "333 Biblia/San Juan/1/Jn 1, 1-5 En el principio.md",
+        }),
+      );
+    });
+
+    it("rescans the vault and supports alias substring matching for locations", async () => {
+      const fixture = createBibleFixture();
+
+      await openLocationNote(
+        fixture.app,
+        "[[lugar-inexistente|Jerusalén]]",
+      );
+
+      expect(fixture.getFiles).toHaveBeenCalledTimes(1);
+      expect(fixture.filterSpy).toHaveBeenCalledTimes(1);
+      expect(mockOpenVaultNote).toHaveBeenCalledWith(
+        fixture.app,
+        expect.objectContaining({
+          path: "300 Lugares/Mapa Jerusalén antiguo.md",
+        }),
+      );
+    });
+  });
+});

--- a/src/core/notes/bible/BibleViewChapters.ts
+++ b/src/core/notes/bible/BibleViewChapters.ts
@@ -92,6 +92,164 @@ async function getLocationCoordinates(
 	return yaml.location;
 }
 
+interface PendingLocation {
+	location: string;
+	note: Note;
+}
+
+async function buildChapterNotes(
+	app: App,
+	chapterFiles: TFile[],
+	pendingLocations?: PendingLocation[]
+): Promise<Note[]> {
+	const notes: Note[] = [];
+
+	for (const file of chapterFiles) {
+		const noteData = await getNoteData(app, file.path);
+		if (!noteData.path) {
+			continue;
+		}
+
+		const location = noteData.locations?.[0];
+		const coordinates =
+			location && !pendingLocations
+				? await getLocationCoordinates(app, location)
+				: null;
+		const note = {
+			...noteData,
+			verseRange: noteData.verseRange || [0, 0],
+			pericopeTitle: noteData.verse_title,
+			title: noteData.verse_title,
+			alt: noteData.alt,
+			coordinates,
+		} as Note;
+
+		notes.push(note);
+		if (location && pendingLocations) {
+			pendingLocations.push({ location, note });
+		}
+	}
+
+	notes.sort((a, b) => a.verseRange[0] - b.verseRange[0]);
+	return notes;
+}
+
+function buildBibleIndex(files: TFile[]): Map<string, TFile[]> {
+	const index = new Map<string, TFile[]>();
+	const validChapters = new Map<string, Set<string>>(
+		Object.entries(bibleStructure).map(([book, data]) => [
+			book,
+			new Set(Object.keys(data.chapters)),
+		])
+	);
+
+	for (const file of files) {
+		const [rootFolder, book, chapterFolder] = file.path.split("/");
+		const bookChapters = validChapters.get(book);
+		if (rootFolder !== "333 Biblia" || !bookChapters) {
+			continue;
+		}
+
+		if (book === "Salmos") {
+			const psalmMatch = file.basename.match(/Sal (\d+),/);
+			const chapterNumber = psalmMatch?.[1];
+			if (!chapterNumber || !bookChapters.has(chapterNumber)) {
+				continue;
+			}
+
+			const key = `${book}-${chapterNumber}`;
+			if (!index.has(key)) {
+				index.set(key, [file]);
+			}
+			continue;
+		}
+
+		if (!chapterFolder || !bookChapters.has(chapterFolder)) {
+			continue;
+		}
+
+		const key = `${book}-${chapterFolder}`;
+		const chapterFiles = index.get(key);
+		if (chapterFiles) {
+			chapterFiles.push(file);
+		} else {
+			index.set(key, [file]);
+		}
+	}
+
+	return index;
+}
+
+function parseLocation(location: string): {
+	mainLocation: string;
+	alias?: string;
+} {
+	const sanitizedLocation = location.replace(/\[\[|\]\]/g, "");
+	const [mainLocation, alias] = sanitizedLocation.split("|");
+	return { mainLocation, alias };
+}
+
+async function resolveLocationsInBatch(
+	app: App,
+	files: TFile[],
+	pendingLocations: PendingLocation[]
+): Promise<void> {
+	if (pendingLocations.length === 0) {
+		return;
+	}
+
+	const unresolved = new Map(
+		pendingLocations.map(({ location }) => [location, parseLocation(location)])
+	);
+	const matches = new Map<string, TFile>();
+
+	for (const file of files) {
+		for (const [location, query] of unresolved) {
+			if (
+				file.basename.includes(query.mainLocation) ||
+				(query.alias && file.basename.includes(query.alias))
+			) {
+				matches.set(location, file);
+				unresolved.delete(location);
+			}
+		}
+
+		if (unresolved.size === 0) {
+			break;
+		}
+	}
+
+	const coordinatesByLocation = new Map<
+		string,
+		[number, number] | null
+	>();
+	for (const location of new Set(
+		pendingLocations.map((pending) => pending.location)
+	)) {
+		const noteFile = matches.get(location);
+		if (!noteFile) {
+			console.log(
+				`getLocationCoordinates: No se encontró ninguna nota con el nombre ${location.replace(
+					/\[\[|\]\]/g,
+					""
+				)}`
+			);
+			coordinatesByLocation.set(location, null);
+			continue;
+		}
+
+		const yaml = app.metadataCache.getFileCache(noteFile)?.frontmatter;
+		coordinatesByLocation.set(location, yaml?.location || null);
+	}
+
+	for (const pending of pendingLocations) {
+		const coordinates = coordinatesByLocation.get(pending.location);
+		if (coordinates) {
+			pending.note.coordinates = coordinates;
+		}
+	}
+}
+
 export async function getChapterNotes(
 	app: App,
 	book: string,
@@ -104,62 +262,16 @@ export async function getChapterNotes(
 	const files = app.vault
 		.getFiles()
 		.filter((file) => file.path.startsWith(folderPath));
-	const notes: Note[] = [];
 
 	if (book === "Salmos") {
 		// Filtrar el archivo correspondiente al capítulo especificado
 		const chapterFile = files.find((file) =>
 			file.basename.includes(`Sal ${chapterNumber},`)
 		);
-		if (chapterFile) {
-			const noteData = await getNoteData(app, chapterFile.path);
-			if (noteData.path) {
-				const coordinates =
-					noteData.locations && noteData.locations.length > 0
-						? await getLocationCoordinates(
-								app,
-								noteData.locations[0]
-						  )
-						: null;
-
-				notes.push({
-					...noteData,
-					verseRange: noteData.verseRange || [0, 0], // Usar el verseRange calculado
-					pericopeTitle: noteData.verse_title,
-					title: noteData.verse_title,
-					alt: noteData.alt,
-					coordinates,
-				} as Note);
-			}
-		}
-	} else {
-		for (const file of files) {
-			const noteData = await getNoteData(app, file.path);
-			if (noteData.path) {
-				const coordinates =
-					noteData.locations && noteData.locations.length > 0
-						? await getLocationCoordinates(
-								app,
-								noteData.locations[0]
-						  )
-						: null;
-
-				notes.push({
-					...noteData,
-					verseRange: noteData.verseRange || [0, 0], // Usar el verseRange calculado
-					pericopeTitle: noteData.verse_title,
-					title: noteData.verse_title,
-					alt: noteData.alt,
-					coordinates,
-				} as Note);
-			}
-		}
+		return buildChapterNotes(app, chapterFile ? [chapterFile] : []);
 	}
 
-	// Ordenar las notas por el primer versículo de verseRange
-	notes.sort((a, b) => a.verseRange[0] - b.verseRange[0]);
-
-	return notes;
+	return buildChapterNotes(app, files);
 }
 
 export async function openNote(
@@ -224,15 +336,21 @@ export async function openLocationNote(
 export async function fetchChapterNotes(
 	app: App
 ): Promise<{ [key: string]: Note[] }> {
+	const files = app.vault.getFiles();
+	const bibleIndex = buildBibleIndex(files);
+	const pendingLocations: PendingLocation[] = [];
 	const notes: { [key: string]: Note[] } = {};
 	for (const [book, data] of Object.entries(bibleStructure)) {
 		for (const chapterNumber of Object.keys(data.chapters)) {
-			notes[`${book}-${chapterNumber}`] = await getChapterNotes(
+			const key = `${book}-${chapterNumber}`;
+			notes[key] = await buildChapterNotes(
 				app,
-				book,
-				chapterNumber
+				bibleIndex.get(key) || [],
+				pendingLocations
 			);
 		}
 	}
+
+	await resolveLocationsInBatch(app, files, pendingLocations);
 	return notes;
 }


### PR DESCRIPTION
## Summary

- reduces Bible hydration from 1088+ full-vault passes to at most two
- takes one fresh vault snapshot per `fetchChapterNotes()` invocation
- builds a transient Bible chapter index from that snapshot
- preserves the flat Salmos folder semantics
- resolves all Bible locations in a single ordered batch pass
- preserves substring, alias and first-match location semantics
- keeps all indexes local to a single hydration with no persistent cache

## Performance baseline

Before, without locations:

- `getFiles()` calls: 1088
- full-vault traversals: 1088
- full-array filters: 1088

Before, with one location:

- `getFiles()` calls: 1089
- full-vault traversals: 1089
- full-array filters: 1089

After, without locations:

- `getFiles()` calls: 1
- full-vault traversals: 1
- full-array filters: 0

After, with locations:

- `getFiles()` calls: 1
- full-vault traversals: at most 2
- full-array filters: 0

Three distinct location queries still require only one snapshot and at most two complete traversals.

## Functional preservation

The regression suite covers:

- all 1088 chapter keys
- regular Bible books
- chapter ordering
- empty chapters
- nested chapter subdirectories
- Salmos flat-folder indexing
- first matching Psalm
- verse-range fallback
- rating, title, cover and metadata
- location coordinates
- substring location matching
- alias matching
- first-match snapshot order
- fresh snapshot on every hydration

## Complexity

The hydration path changes from approximately:

`O(chapters × vaultFiles + locations × vaultFiles)`

to approximately:

`O(vaultFiles + chapters + relevantBibleNotes + batchedLocationMatching)`.

## Validation

- 12 Jest suites passed
- 71 tests passed
- 0 expected failures
- 0 unexpected failures
- TypeScript check passed
- production build passed
- manual validation in Obsidian passed

## Scope

This PR intentionally does not:

- optimize interactive `openNote`
- modify `openLocationNote`
- introduce persistent caching or vault listeners
- change Bible UI or navigation
- change Calendar or Timeline
- update dependencies or tooling
