### PR TITLE
perf: consolidate Calendar year data ownership

### DIFF
--- a/src/core/notes/calendar/CalendarYear.test.tsx
+++ b/src/core/notes/calendar/CalendarYear.test.tsx
@@ -1,0 +1,60 @@
+const mockApp = { name: 'calendar-app' };
+const mockUseApp = jest.fn(() => mockApp);
+const mockUseCalendarYearLogic = jest.fn();
+
+jest.mock('./../../hooks/useApp', () => ({
+  useApp: mockUseApp,
+}));
+jest.mock('./Month', () => ({
+  useCalendarYearLogic: mockUseCalendarYearLogic,
+}));
+jest.mock('./MonthUI', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+import React from 'react';
+import CalendarYear from './CalendarYear';
+import MonthUI from './MonthUI';
+
+describe('CalendarYear structure and ownership', () => {
+  beforeEach(() => {
+    mockUseApp.mockClear();
+    mockUseCalendarYearLogic.mockReset();
+  });
+
+  test('uses one annual owner and renders its 12 prepared months', () => {
+    const year = 2026;
+    const preparedMonths = Array.from({ length: 12 }, (_, index) => ({
+      cssCurrentMonth: index === 7 ? 'obs-current-month' : '',
+      daysGrid: [],
+      month: index + 1,
+      monthNameAndYear: `Month ${index + 1} ${year}`,
+      year,
+    }));
+    mockUseCalendarYearLogic.mockReturnValue({ months: preparedMonths });
+
+    const calendarYear = CalendarYear({ year });
+    const container = React.Children.only(
+      calendarYear.props.children,
+    ) as React.ReactElement<{ children: React.ReactNode }>;
+    const months = container.props.children as Array<
+      React.ReactElement<(typeof preparedMonths)[number]>
+    >;
+
+    expect(mockUseApp).toHaveBeenCalledTimes(1);
+    expect(mockUseCalendarYearLogic).toHaveBeenCalledTimes(1);
+    expect(mockUseCalendarYearLogic).toHaveBeenCalledWith(mockApp, year);
+    expect(months).toHaveLength(12);
+    expect(months.map((element) => element.type)).toEqual(
+      Array(12).fill(MonthUI),
+    );
+    expect(months.map((element) => element.props)).toEqual(preparedMonths);
+    expect(months.map((element) => element.key)).toEqual(
+      Array.from(
+        { length: 12 },
+        (_, index) => `${year}-${String(index + 1).padStart(2, '0')}`,
+      ),
+    );
+  });
+});

--- a/src/core/notes/calendar/CalendarYear.tsx
+++ b/src/core/notes/calendar/CalendarYear.tsx
@@ -1,3 +1,5 @@
+import { useApp } from './../../hooks/useApp';
+import { useCalendarYearLogic } from './Month';
 import MonthUI from './MonthUI';
 
 interface CalendarYearProps {
@@ -5,14 +7,12 @@ interface CalendarYearProps {
 }
 
 function CalendarYear({ year }: CalendarYearProps): JSX.Element {
-  
-  const monthsGrid = Array.from({ length: 12 }, (_, month) => {
-    month = month + 1;
-    const monthKey = `${year}-${(month).toString().padStart(2, '0')}`;
-    
-    return (
-      <MonthUI key={monthKey} year={year} month={month} /> 
-    );
+  const app = useApp();
+  const { months } = useCalendarYearLogic(app, year);
+  const monthsGrid = months.map((monthData) => {
+    const monthKey = `${year}-${monthData.month.toString().padStart(2, '0')}`;
+
+    return <MonthUI key={monthKey} {...monthData} />;
   });
 
   return (
@@ -20,7 +20,6 @@ function CalendarYear({ year }: CalendarYearProps): JSX.Element {
       <div className='months-container'>{monthsGrid}</div>
     </>
   );
-
 }
 
 export default CalendarYear;

--- a/src/core/notes/calendar/Month.test.ts
+++ b/src/core/notes/calendar/Month.test.ts
@@ -1,82 +1,592 @@
 const mockEffects: Array<() => void | (() => void)> = [];
+const mockStateSetters: jest.Mock[] = [];
 const mockUseEffect = jest.fn((effect: () => void | (() => void)) => {
   mockEffects.push(effect);
 });
-const mockUseRef = jest.fn(() => ({ current: null }));
-const mockUseState = jest.fn((initialValue: unknown) => [initialValue, jest.fn()]);
+const mockUseState = jest.fn((initialValue: unknown) => {
+  const value =
+    typeof initialValue === 'function'
+      ? (initialValue as () => unknown)()
+      : initialValue;
+  const setter = jest.fn();
+  mockStateSetters.push(setter);
+  return [value, setter];
+});
 
 jest.mock('react', () => ({
   useEffect: mockUseEffect,
-  useRef: mockUseRef,
   useState: mockUseState,
 }));
 
-import { useMonthLogic } from './Month';
+import {
+  buildCalendarYearIndex,
+  calculateNumRows,
+  createCalendarYearMonths,
+  createDaysGrid,
+  createDaysGridFromIndex,
+  getAnniversaryNote,
+  getDailyNote,
+  getDayNotes,
+  getDayOffset,
+  getFirstDayOfMonth,
+  getLastDayOfMonth,
+  useCalendarYearLogic,
+} from './Month';
 
-function createFakeApp() {
+interface FixtureFile {
+  path: string;
+  basename: string;
+}
+
+interface FakeAppOptions {
+  files?: FixtureFile[];
+  frontmatterByPath?: Map<string, Record<string, unknown>>;
+}
+
+function createFakeApp({
+  files = [],
+  frontmatterByPath = new Map(),
+}: FakeAppOptions = {}) {
   const vaultOn = jest.fn();
   const vaultOff = jest.fn();
   const metadataOn = jest.fn();
   const metadataOff = jest.fn();
+  const getMarkdownFiles = jest.fn().mockReturnValue(files);
+  const getFileCache = jest.fn((file: FixtureFile) => ({
+    frontmatter: frontmatterByPath.get(file.path),
+  }));
 
   return {
     app: {
       vault: {
-        getMarkdownFiles: jest.fn().mockReturnValue([]),
+        getMarkdownFiles,
         on: vaultOn,
         off: vaultOff,
       },
       metadataCache: {
-        getFileCache: jest.fn(),
+        getFileCache,
         on: metadataOn,
         off: metadataOff,
       },
     },
-    vaultOn,
-    vaultOff,
-    metadataOn,
+    getFileCache,
+    getMarkdownFiles,
     metadataOff,
+    metadataOn,
+    vaultOff,
+    vaultOn,
   };
 }
 
-describe('useMonthLogic listener lifecycle', () => {
+function getGridMetrics(year: number, month: number) {
+  const firstDay = getFirstDayOfMonth(year, month - 1);
+  const lastDay = getLastDayOfMonth(year, month - 1);
+  const numDaysInMonth = lastDay.getDate();
+  const dayOffset = getDayOffset(firstDay.getDay());
+  const numRows = calculateNumRows(numDaysInMonth, dayOffset);
+
+  return {
+    dayOffset,
+    gridCells: numRows * 7,
+    numDaysInMonth,
+    numRows,
+  };
+}
+
+function runEffects() {
+  return mockEffects
+    .map((effect) => effect())
+    .filter((cleanup): cleanup is () => void => typeof cleanup === 'function');
+}
+
+function createAnnualFixture() {
+  const files: FixtureFile[] = [
+    {
+      path: '100 Calendar/2026/08/20260815.md',
+      basename: '20260815',
+    },
+    {
+      path: '200 Events/August event.md',
+      basename: 'August event',
+    },
+    {
+      path: '200 Events/December event.md',
+      basename: 'December event',
+    },
+    {
+      path: '200 People/Aniversaries/08/0815.md',
+      basename: '0815',
+    },
+    {
+      path: '900 Unrelated/No calendar metadata.md',
+      basename: 'No calendar metadata',
+    },
+  ];
+  const frontmatterByPath = new Map<string, Record<string, unknown>>([
+    [files[0].path, {}],
+    [files[1].path, { date: '2026-08-15T10:00:00' }],
+    [files[2].path, { date: '2026-12-25T12:00:00' }],
+    [files[3].path, {}],
+    [files[4].path, {}],
+  ]);
+
+  return {
+    ...createFakeApp({ files, frontmatterByPath }),
+    files,
+    frontmatterByPath,
+  };
+}
+
+function flattenGrid<T>(grid: T[][]): T[] {
+  return grid.reduce((all, row) => all.concat(row), [] as T[]);
+}
+
+function comparableGrid(grid: ReturnType<typeof createDaysGrid>) {
+  return grid.map((row) =>
+    row.map(({ app: _app, ...cell }) => cell),
+  );
+}
+
+describe('useCalendarYearLogic ownership', () => {
   beforeEach(() => {
     mockEffects.length = 0;
+    mockStateSetters.length = 0;
     mockUseEffect.mockClear();
-    mockUseRef.mockClear();
     mockUseState.mockClear();
   });
 
-  test('registers create, delete and changed once with one update callback', () => {
-    const { app, vaultOn, metadataOn } = createFakeApp();
-
-    useMonthLogic(app as any, 2026, 8);
-    mockEffects[0]();
-
-    expect(vaultOn).toHaveBeenCalledTimes(2);
-    expect(metadataOn).toHaveBeenCalledTimes(1);
-    expect(vaultOn).toHaveBeenNthCalledWith(1, 'create', expect.any(Function));
-    expect(vaultOn).toHaveBeenNthCalledWith(2, 'delete', expect.any(Function));
-    expect(metadataOn).toHaveBeenCalledWith('changed', expect.any(Function));
-
-    const createCallback = vaultOn.mock.calls[0][1];
-    expect(vaultOn.mock.calls[1][1]).toBe(createCallback);
-    expect(metadataOn.mock.calls[0][1]).toBe(createCallback);
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
-  test('returns cleanup that removes all listeners with their registered callback', () => {
-    const { app, vaultOn, vaultOff, metadataOn, metadataOff } = createFakeApp();
+  test('takes one initial snapshot and derives all months in one snapshot pass', () => {
+    const fixture = createAnnualFixture();
+    const originalIterator = fixture.files[Symbol.iterator].bind(fixture.files);
+    const iteratorSpy = jest
+      .spyOn(fixture.files, Symbol.iterator)
+      .mockImplementation(() => originalIterator());
+    const findSpy = jest.spyOn(fixture.files, 'find');
+    const filterSpy = jest.spyOn(fixture.files, 'filter');
 
-    useMonthLogic(app as any, 2026, 8);
-    const cleanup = mockEffects[0]();
+    const result = useCalendarYearLogic(fixture.app as any, 2026);
 
-    expect(cleanup).toEqual(expect.any(Function));
-    cleanup!();
+    expect(mockUseState).toHaveBeenCalledWith(expect.any(Function));
+    expect(fixture.getMarkdownFiles).toHaveBeenCalledTimes(1);
+    expect(iteratorSpy).toHaveBeenCalledTimes(1);
+    expect(findSpy).not.toHaveBeenCalled();
+    expect(filterSpy).not.toHaveBeenCalled();
+    expect(fixture.getFileCache).toHaveBeenCalledTimes(fixture.files.length);
+    expect(result.months).toHaveLength(12);
+    expect(
+      result.months.reduce(
+        (total, month) => total + month.daysGrid.length * 7,
+        0,
+      ),
+    ).toBe(441);
+  });
 
-    expect(vaultOff).toHaveBeenCalledTimes(2);
-    expect(metadataOff).toHaveBeenCalledTimes(1);
-    expect(vaultOff).toHaveBeenNthCalledWith(1, 'create', vaultOn.mock.calls[0][1]);
-    expect(vaultOff).toHaveBeenNthCalledWith(2, 'delete', vaultOn.mock.calls[1][1]);
-    expect(metadataOff).toHaveBeenCalledWith('changed', metadataOn.mock.calls[0][1]);
+  test('registers three listeners with one shared update callback', () => {
+    const fixture = createFakeApp();
+
+    useCalendarYearLogic(fixture.app as any, 2026);
+    const cleanups = runEffects();
+
+    expect(cleanups).toHaveLength(1);
+    expect(fixture.vaultOn).toHaveBeenCalledTimes(2);
+    expect(fixture.metadataOn).toHaveBeenCalledTimes(1);
+    expect(fixture.vaultOn).toHaveBeenNthCalledWith(
+      1,
+      'create',
+      expect.any(Function),
+    );
+    expect(fixture.vaultOn).toHaveBeenNthCalledWith(
+      2,
+      'delete',
+      expect.any(Function),
+    );
+    expect(fixture.metadataOn).toHaveBeenCalledWith(
+      'changed',
+      expect.any(Function),
+    );
+    expect(fixture.vaultOn.mock.calls[0][1]).toBe(
+      fixture.vaultOn.mock.calls[1][1],
+    );
+    expect(fixture.vaultOn.mock.calls[0][1]).toBe(
+      fixture.metadataOn.mock.calls[0][1],
+    );
+  });
+
+  test.each([
+    ['create', 'vault'],
+    ['delete', 'vault'],
+    ['changed', 'metadata'],
+  ] as const)(
+    'one %s event takes one snapshot and performs one state update',
+    (event, source) => {
+      const fixture = createFakeApp();
+      useCalendarYearLogic(fixture.app as any, 2026);
+      runEffects();
+      const callsBefore = fixture.getMarkdownFiles.mock.calls.length;
+      const registration =
+        source === 'vault'
+          ? fixture.vaultOn.mock.calls.find(
+              ([registeredEvent]) => registeredEvent === event,
+            )
+          : fixture.metadataOn.mock.calls.find(
+              ([registeredEvent]) => registeredEvent === event,
+            );
+
+      registration![1]();
+
+      expect(fixture.getMarkdownFiles.mock.calls.length - callsBefore).toBe(1);
+      expect(mockStateSetters).toHaveLength(1);
+      expect(mockStateSetters[0]).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test('cleans up all three listeners symmetrically', () => {
+    const fixture = createFakeApp();
+
+    useCalendarYearLogic(fixture.app as any, 2026);
+    const [cleanup] = runEffects();
+    cleanup();
+
+    expect(fixture.vaultOff).toHaveBeenCalledTimes(2);
+    expect(fixture.metadataOff).toHaveBeenCalledTimes(1);
+    fixture.vaultOn.mock.calls.forEach(([event, callback]) => {
+      expect(fixture.vaultOff).toHaveBeenCalledWith(event, callback);
+    });
+    fixture.metadataOn.mock.calls.forEach(([event, callback]) => {
+      expect(fixture.metadataOff).toHaveBeenCalledWith(event, callback);
+    });
+  });
+});
+
+describe('Month reference lookup semantics', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('getDailyNote requires the current exact calendar path', () => {
+    const files: FixtureFile[] = [
+      {
+        path: 'archive/100 Calendar/2026/08/20260815.md',
+        basename: 'wrong prefix',
+      },
+      {
+        path: '100 Calendar/2026/08/20260815.md.backup',
+        basename: 'wrong suffix',
+      },
+      {
+        path: '100 Calendar/2026/08/20260815.md',
+        basename: '20260815',
+      },
+    ];
+
+    expect(getDailyNote(15, files as any, 2026, 8)).toBe(files[2].path);
+    expect(getDailyNote(16, files as any, 2026, 8)).toBe(false);
+  });
+
+  test('getAnniversaryNote preserves the Aniversaries month/day route', () => {
+    const files: FixtureFile[] = [
+      {
+        path: '200 People/Anniversaries/08/0815.md',
+        basename: 'wrong spelling',
+      },
+      {
+        path: '200 People/Aniversaries/08/0815.md',
+        basename: '0815',
+      },
+    ];
+
+    expect(getAnniversaryNote(15, files as any, 8)).toBe(files[1]);
+    expect(getAnniversaryNote(16, files as any, 8)).toBeUndefined();
+  });
+
+  test('getDayNotes includes only matching dated events', () => {
+    const files: FixtureFile[] = [
+      { path: '200 Events/matching.md', basename: 'matching' },
+      { path: '200 Events/other day.md', basename: 'other day' },
+      { path: '100 Calendar/2026/08/15.md', basename: '15' },
+      { path: '200 People/Aniversaries/08/0815.md', basename: '0815' },
+      { path: '900 Archive/20260815.md', basename: '20260815' },
+      { path: '200 Events/missing date.md', basename: 'missing date' },
+      { path: '200 Events/non-string date.md', basename: 'non-string date' },
+    ];
+    const frontmatterByPath = new Map<string, Record<string, unknown>>([
+      [files[0].path, { date: '2026-08-15T10:30:00' }],
+      [files[1].path, { date: '2026-08-16T10:30:00' }],
+      [files[5].path, {}],
+      [files[6].path, { date: new Date(2026, 7, 15) }],
+    ]);
+    const fixture = createFakeApp({ files, frontmatterByPath });
+
+    expect(
+      getDayNotes(
+        fixture.app as any,
+        fixture.app.metadataCache as any,
+        files as any,
+        15,
+        2026,
+        8,
+      ),
+    ).toEqual([files[0]]);
+  });
+});
+
+describe('Calendar year index semantics', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('indexes a daily note only when it survives the old monthly prefilter', () => {
+    const files: FixtureFile[] = [
+      {
+        path: '100 Calendar/2026/08/20260815.md',
+        basename: '20260815',
+      },
+      {
+        path: '100 Calendar/2026/08/20260816.md',
+        basename: '20260816',
+      },
+      {
+        path: 'archive/100 Calendar/2026/08/20260817.md',
+        basename: '20260817',
+      },
+    ];
+    const frontmatterByPath = new Map<string, Record<string, unknown>>([
+      [files[0].path, {}],
+      [files[1].path, { date: '2026-08-16' }],
+      [files[2].path, { date: '2026-08-17' }],
+    ]);
+    const fixture = createFakeApp({ files, frontmatterByPath });
+
+    const index = buildCalendarYearIndex(
+      files as any,
+      fixture.app.metadataCache as any,
+      2026,
+    );
+
+    expect(index.dailyNoteByDate.has('2026-08-15')).toBe(false);
+    expect(index.dailyNoteByDate.get('2026-08-16')).toBe(files[1].path);
+    expect(index.dailyNoteByDate.has('2026-08-17')).toBe(false);
+  });
+
+  test('preserves anniversary spelling, substring matching and first match', () => {
+    const files: FixtureFile[] = [
+      {
+        path: 'A/Aniversaries/08/0815.md extra',
+        basename: 'first',
+      },
+      {
+        path: 'B/Aniversaries/08/0815.md',
+        basename: 'second',
+      },
+      {
+        path: 'C/Anniversaries/08/0815.md',
+        basename: 'wrong spelling',
+      },
+    ];
+    const fixture = createFakeApp({ files });
+
+    const index = buildCalendarYearIndex(
+      files as any,
+      fixture.app.metadataCache as any,
+      2026,
+    );
+
+    expect(index.anniversaryByMonthDay.get('08-15')).toBe(files[0]);
+  });
+
+  test('preserves event exclusions, date parsing and snapshot order', () => {
+    const files: FixtureFile[] = [
+      { path: '200 Events/first.md', basename: 'first' },
+      { path: '200 Events/second.md', basename: 'second' },
+      { path: '200 Events/other day.md', basename: 'other day' },
+      { path: '100 Calendar/2026/08/15.md', basename: '15' },
+      { path: '200 People/Aniversaries/08/0815.md', basename: '0815' },
+      { path: '900 Archive/20260815.md', basename: '20260815' },
+      { path: '200 Events/missing.md', basename: 'missing' },
+      { path: '200 Events/non-string.md', basename: 'non-string' },
+      { path: '200 Events/non-monthly-format.md', basename: 'format' },
+    ];
+    const frontmatterByPath = new Map<string, Record<string, unknown>>([
+      [files[0].path, { date: '2026-08-15T09:00:00' }],
+      [files[1].path, { date: '2026-08-15T08:00:00' }],
+      [files[2].path, { date: '2026-08-16T10:00:00' }],
+      [files[3].path, { date: '2026-08-15T10:00:00' }],
+      [files[4].path, { date: '2026-08-15T10:00:00' }],
+      [files[5].path, { date: '2026-08-15T10:00:00' }],
+      [files[6].path, {}],
+      [files[7].path, { date: new Date(2026, 7, 15) }],
+      [files[8].path, { date: '2026X08X15' }],
+    ]);
+    const fixture = createFakeApp({ files, frontmatterByPath });
+
+    const index = buildCalendarYearIndex(
+      files as any,
+      fixture.app.metadataCache as any,
+      2026,
+    );
+
+    expect(index.eventsByDate.get('2026-08-15')).toEqual([
+      files[0],
+      files[1],
+    ]);
+    expect(index.eventsByDate.get('2026-08-16')).toEqual([files[2]]);
+    expect(fixture.getFileCache).toHaveBeenCalledTimes(files.length);
+  });
+
+  test('produces a grid functionally equivalent to the reference pipeline', () => {
+    const year = 2026;
+    const month = 8;
+    const metrics = getGridMetrics(year, month);
+    const files: FixtureFile[] = [
+      {
+        path: '100 Calendar/2026/08/20260815.md',
+        basename: '20260815',
+      },
+      { path: '200 Events/August 15.md', basename: 'August 15' },
+      { path: '200 Events/August 16.md', basename: 'August 16' },
+      {
+        path: '200 People/Aniversaries/08/0815.md',
+        basename: '0815',
+      },
+      { path: '900 Unrelated/no date.md', basename: 'no date' },
+    ];
+    const frontmatterByPath = new Map<string, Record<string, unknown>>([
+      [files[0].path, { date: '2026-08-15' }],
+      [files[1].path, { date: '2026-08-15T10:00:00' }],
+      [files[2].path, { date: '2026-08-16T10:00:00' }],
+      [files[3].path, {}],
+      [files[4].path, {}],
+    ]);
+    const fixture = createFakeApp({ files, frontmatterByPath });
+    const filteredFiles = files.filter((file) => {
+      const eventDate = fixture.app.metadataCache.getFileCache(file)?.frontmatter
+        ?.date;
+      return (
+        (typeof eventDate === 'string' && eventDate.includes('2026-08')) ||
+        file.path.includes('/Aniversaries/08')
+      );
+    });
+    const referenceGrid = createDaysGrid({
+      app: fixture.app as any,
+      metadataCache: fixture.app.metadataCache as any,
+      files: filteredFiles as any,
+      ...metrics,
+      year,
+      month,
+    });
+    const index = buildCalendarYearIndex(
+      files as any,
+      fixture.app.metadataCache as any,
+      year,
+    );
+
+    const indexedGrid = createDaysGridFromIndex({
+      app: fixture.app as any,
+      index,
+      ...metrics,
+      year,
+      month,
+    });
+
+    expect(comparableGrid(indexedGrid)).toEqual(comparableGrid(referenceGrid));
+  });
+});
+
+describe('Calendar grid performance characterization', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('reference grid performs two finds and one filter per cell', () => {
+    const year = 2026;
+    const month = 8;
+    const metrics = getGridMetrics(year, month);
+    const files: FixtureFile[] = [
+      {
+        path: '100 Calendar/2026/08/20260815.md',
+        basename: '20260815',
+      },
+      { path: '200 Events/August 15.md', basename: 'August 15' },
+      { path: '200 Events/August 16.md', basename: 'August 16' },
+      {
+        path: '200 People/Aniversaries/08/0815.md',
+        basename: '0815',
+      },
+      { path: '900 Unrelated/no date.md', basename: 'no date' },
+    ];
+    const frontmatterByPath = new Map<string, Record<string, unknown>>([
+      [files[0].path, {}],
+      [files[1].path, { date: '2026-08-15T10:00:00' }],
+      [files[2].path, { date: '2026-08-16T10:00:00' }],
+      [files[3].path, {}],
+      [files[4].path, {}],
+    ]);
+    const fixture = createFakeApp({ files, frontmatterByPath });
+    const findSpy = jest.spyOn(files, 'find');
+    const filterSpy = jest.spyOn(files, 'filter');
+
+    createDaysGrid({
+      app: fixture.app as any,
+      metadataCache: fixture.app.metadataCache as any,
+      files: files as any,
+      ...metrics,
+      year,
+      month,
+    });
+
+    expect(metrics.numRows).toBe(6);
+    expect(metrics.gridCells).toBe(42);
+    expect(findSpy).toHaveBeenCalledTimes(84);
+    expect(filterSpy).toHaveBeenCalledTimes(42);
+    expect(fixture.getFileCache).toHaveBeenCalledTimes(126);
+  });
+
+  test('indexed grids perform no snapshot search or metadata lookup per cell', () => {
+    const year = 2026;
+    const fixture = createAnnualFixture();
+    const index = buildCalendarYearIndex(
+      fixture.files as any,
+      fixture.app.metadataCache as any,
+      year,
+    );
+    const metadataLookupsAfterIndex = fixture.getFileCache.mock.calls.length;
+    const findSpy = jest.spyOn(fixture.files, 'find');
+    const filterSpy = jest.spyOn(fixture.files, 'filter');
+
+    const months = createCalendarYearMonths(
+      fixture.app as any,
+      index,
+      year,
+    );
+
+    expect(months).toHaveLength(12);
+    expect(
+      months.reduce(
+        (total, month) => total + month.daysGrid.length * 7,
+        0,
+      ),
+    ).toBe(441);
+    expect(findSpy).not.toHaveBeenCalled();
+    expect(filterSpy).not.toHaveBeenCalled();
+    expect(fixture.getFileCache).toHaveBeenCalledTimes(
+      metadataLookupsAfterIndex,
+    );
+  });
+
+  test('records the full-year reference search volume dynamically', () => {
+    const year = 2026;
+    const totalGridCells = Array.from({ length: 12 }, (_, index) => index + 1)
+      .map((month) => getGridMetrics(year, month).gridCells)
+      .reduce((total, gridCells) => total + gridCells, 0);
+    const repeatedFinds = totalGridCells * 2;
+    const repeatedFilters = totalGridCells;
+
+    expect(totalGridCells).toBe(441);
+    expect(repeatedFinds).toBe(882);
+    expect(repeatedFilters).toBe(441);
   });
 });

--- a/src/core/notes/calendar/Month.ts
+++ b/src/core/notes/calendar/Month.ts
@@ -1,5 +1,5 @@
 import { App, MetadataCache, TFile } from 'obsidian';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export interface CalendarMonthProps {
     year: number;
@@ -20,6 +20,30 @@ export interface MonthGridProps {
     }[][];
 }
 
+export interface CalendarYearIndex {
+    dailyNoteByDate: Map<string, string>;
+    anniversaryByMonthDay: Map<string, TFile>;
+    eventsByDate: Map<string, TFile[]>;
+}
+
+export interface CalendarMonthViewModel extends CalendarMonthProps {
+    cssCurrentMonth: string;
+    monthNameAndYear: string;
+    daysGrid: MonthGridProps['daysGrid'];
+}
+
+function pad2(value: number): string {
+    return String(value).padStart(2, '0');
+}
+
+function calendarDateKey(year: number, month: number, day: number): string {
+    return `${year}-${pad2(month)}-${pad2(day)}`;
+}
+
+function monthDayKey(month: number, day: number): string {
+    return `${pad2(month)}-${pad2(day)}`;
+}
+
 export function getFirstDayOfMonth(year: number, month: number): Date {
     return new Date(year, month, 1);
 }
@@ -36,12 +60,13 @@ export function calculateNumRows(numDaysInMonth: number, dayOffset: number): num
     return Math.ceil((numDaysInMonth + dayOffset) / 7);
 }
 
-// Nueva función para obtener la nota de aniversario
+// Reference helper retained to protect the historical lookup semantics.
 export function getAnniversaryNote(dayIndex: number, files: TFile[], month: number): TFile | undefined {
     const anniversaryPath = `/Aniversaries/${String(month).padStart(2, '0')}/${String(month).padStart(2, '0')}${String(dayIndex).padStart(2, '0')}.md`;
     return files.find(file => file.path.includes(anniversaryPath));
 }
 
+// Reference helper retained to protect the historical lookup semantics.
 export function getDailyNote(dayIndex: number, files: TFile[], year: number, month: number): string | false {
     const dayPadded = String(dayIndex).padStart(2, '0');
     const monthPadded = String(month).padStart(2, '0');
@@ -57,6 +82,7 @@ export function getDailyNote(dayIndex: number, files: TFile[], year: number, mon
     return false;
 }
 
+// Reference helper retained to protect the historical lookup semantics.
 export function getDayNotes(app: App, metadataCache: MetadataCache, files: TFile[], dayIndex: number, year: number, month: number): TFile[] {
     const dayPadded = String(dayIndex).padStart(2, '0');
     const monthPadded = String(month).padStart(2, '0');
@@ -64,13 +90,11 @@ export function getDayNotes(app: App, metadataCache: MetadataCache, files: TFile
 
     const dayNotes = files.filter((file) => {
         const path = file.path;
-
-        // Excluir archivos que sigan el patrón YYYYMMDD.md
-        const fileName = path.split('/').pop(); // Obtén el nombre del archivo
-        const regex = /^\d{8}\.md$/; // Expresión regular para YYYYMMDD.md
+        const fileName = path.split('/').pop();
+        const regex = /^\d{8}\.md$/;
 
         if (regex.test(fileName!)) {
-            return false; // Excluir archivos que coincidan con el patrón
+            return false;
         }
 
         if (path === dailyPath || path.includes('/Aniversaries/')) {
@@ -93,6 +117,7 @@ export function getDayNotes(app: App, metadataCache: MetadataCache, files: TFile
     return dayNotes;
 }
 
+// Reference grid retained for equivalence and performance regression tests.
 export function createDaysGrid({
     app,
     metadataCache,
@@ -113,9 +138,9 @@ export function createDaysGrid({
     month: number;
 }): MonthGridProps['daysGrid'] {
     const daysGrid: MonthGridProps['daysGrid'] = [];
-    let currentDay = 1; // Día actual dentro del mes
-    let nextMonthDay = 1; // Día inicial del próximo mes
-    let prevMonthLastDay = getLastDayOfMonth(year, month - 1).getDate(); // Último día del mes anterior
+    let currentDay = 1;
+    let nextMonthDay = 1;
+    const prevMonthLastDay = getLastDayOfMonth(year, month - 1).getDate();
 
     for (let row = 0; row < numRows; row++) {
         const cells: MonthGridProps['daysGrid'][0] = [];
@@ -126,20 +151,16 @@ export function createDaysGrid({
             let isWithinMonth: boolean;
 
             if (cellDay < 1) {
-                // Días del mes anterior
                 dayIndex = prevMonthLastDay + cellDay;
                 isWithinMonth = false;
             } else if (currentDay > numDaysInMonth) {
-                // Días del mes siguiente
                 dayIndex = nextMonthDay++;
                 isWithinMonth = false;
             } else {
-                // Días del mes actual
                 dayIndex = currentDay++;
                 isWithinMonth = true;
             }
 
-            // Solo aseguramos que los días del mes actual tengan isWithinMonth como true
             cells.push({
                 year,
                 month,
@@ -159,8 +180,206 @@ export function createDaysGrid({
     return daysGrid;
 }
 
-export function useMonthLogic(app: App | undefined, year: number, month: number) {
-    const [files, setFiles] = useState<TFile[]>(app?.vault.getMarkdownFiles() || []);
+export function buildCalendarYearIndex(
+    files: TFile[],
+    metadataCache: MetadataCache,
+    year: number
+): CalendarYearIndex {
+    const dailyNoteByDate = new Map<string, string>();
+    const anniversaryByMonthDay = new Map<string, TFile>();
+    const eventsByDate = new Map<string, TFile[]>();
+
+    for (const file of files) {
+        const path = file.path;
+        const eventDate = metadataCache.getFileCache(file)?.frontmatter?.date;
+
+        const dailyMatch = path.match(
+            /^100 Calendar\/(\d{4})\/(\d{2})\/(\d{4})(\d{2})(\d{2})\.md$/
+        );
+        if (dailyMatch) {
+            const folderYear = parseInt(dailyMatch[1]);
+            const folderMonth = parseInt(dailyMatch[2]);
+            const fileYear = parseInt(dailyMatch[3]);
+            const fileMonth = parseInt(dailyMatch[4]);
+            const fileDay = parseInt(dailyMatch[5]);
+            const survivesMonthlyFilter =
+                typeof eventDate === 'string' &&
+                eventDate.includes(`${year}-${pad2(folderMonth)}`);
+
+            if (
+                folderYear === year &&
+                fileYear === year &&
+                folderMonth === fileMonth &&
+                survivesMonthlyFilter
+            ) {
+                const key = calendarDateKey(year, fileMonth, fileDay);
+                if (!dailyNoteByDate.has(key)) {
+                    dailyNoteByDate.set(key, path);
+                }
+            }
+        }
+
+        const anniversaryMatch = path.match(
+            /\/Aniversaries\/(\d{2})\/(\d{2})(\d{2})\.md/
+        );
+        if (anniversaryMatch) {
+            const folderMonth = parseInt(anniversaryMatch[1]);
+            const fileMonth = parseInt(anniversaryMatch[2]);
+            const day = parseInt(anniversaryMatch[3]);
+            if (folderMonth === fileMonth) {
+                const key = monthDayKey(folderMonth, day);
+                if (!anniversaryByMonthDay.has(key)) {
+                    anniversaryByMonthDay.set(key, file);
+                }
+            }
+        }
+
+        const fileName = path.split('/').pop();
+        if (
+            /^\d{8}\.md$/.test(fileName!) ||
+            path.includes('/Aniversaries/') ||
+            typeof eventDate !== 'string'
+        ) {
+            continue;
+        }
+
+        const eventYear = parseInt(eventDate.substring(0, 4));
+        const eventMonth = parseInt(eventDate.substring(5, 7));
+        const eventDay = parseInt(eventDate.substring(8, 10));
+        const dailyPath = `100 Calendar/${year}/${pad2(eventMonth)}/${pad2(eventDay)}.md`;
+        const survivesMonthlyFilter = eventDate.includes(
+            `${year}-${pad2(eventMonth)}`
+        );
+
+        if (
+            eventYear !== year ||
+            !survivesMonthlyFilter ||
+            path === dailyPath
+        ) {
+            continue;
+        }
+
+        const key = calendarDateKey(eventYear, eventMonth, eventDay);
+        const events = eventsByDate.get(key);
+        if (events) {
+            events.push(file);
+        } else {
+            eventsByDate.set(key, [file]);
+        }
+    }
+
+    return {
+        dailyNoteByDate,
+        anniversaryByMonthDay,
+        eventsByDate,
+    };
+}
+
+export function createDaysGridFromIndex({
+    app,
+    index,
+    numRows,
+    numDaysInMonth,
+    dayOffset,
+    year,
+    month
+}: {
+    app: App;
+    index: CalendarYearIndex;
+    numRows: number;
+    numDaysInMonth: number;
+    dayOffset: number;
+    year: number;
+    month: number;
+}): MonthGridProps['daysGrid'] {
+    const daysGrid: MonthGridProps['daysGrid'] = [];
+    let currentDay = 1;
+    let nextMonthDay = 1;
+    const prevMonthLastDay = getLastDayOfMonth(year, month - 1).getDate();
+
+    for (let row = 0; row < numRows; row++) {
+        const cells: MonthGridProps['daysGrid'][0] = [];
+
+        for (let dayOfWeek = 0; dayOfWeek < 7; dayOfWeek++) {
+            const cellDay = row * 7 + dayOfWeek - dayOffset + 1;
+            let dayIndex: number;
+            let isWithinMonth: boolean;
+
+            if (cellDay < 1) {
+                dayIndex = prevMonthLastDay + cellDay;
+                isWithinMonth = false;
+            } else if (currentDay > numDaysInMonth) {
+                dayIndex = nextMonthDay++;
+                isWithinMonth = false;
+            } else {
+                dayIndex = currentDay++;
+                isWithinMonth = true;
+            }
+
+            const dateKey = calendarDateKey(year, month, dayIndex);
+            const events = index.eventsByDate.get(dateKey);
+            cells.push({
+                year,
+                month,
+                dayIndex,
+                isWithinMonth,
+                hasNote: index.dailyNoteByDate.get(dateKey) || false,
+                anniversaryNote: index.anniversaryByMonthDay.get(
+                    monthDayKey(month, dayIndex)
+                ),
+                dayNotes: events ? [...events] : [],
+                className: isWithinMonth ? 'within-month' : 'outside-month',
+                app
+            });
+        }
+
+        daysGrid.push(cells);
+    }
+
+    return daysGrid;
+}
+
+export function createCalendarYearMonths(
+    app: App,
+    index: CalendarYearIndex,
+    year: number
+): CalendarMonthViewModel[] {
+    return Array.from({ length: 12 }, (_, monthIndex) => {
+        const month = monthIndex + 1;
+        const firstDayOfMonth = getFirstDayOfMonth(year, month - 1);
+        const lastDayOfMonth = getLastDayOfMonth(year, month - 1);
+        const numDaysInMonth = lastDayOfMonth.getDate();
+        const dayOffset = getDayOffset(firstDayOfMonth.getDay());
+        const numRows = calculateNumRows(numDaysInMonth, dayOffset);
+        const daysGrid = createDaysGridFromIndex({
+            app,
+            index,
+            numRows,
+            numDaysInMonth,
+            dayOffset,
+            year,
+            month,
+        });
+        const monthName = `${firstDayOfMonth.toLocaleString('default', { month: 'long' })}`;
+        const monthNameFirstCase = monthName.charAt(0).toUpperCase() + monthName.slice(1);
+        const monthNameAndYear = `${monthNameFirstCase} ${year}`;
+        const currentMonth = new Date().getMonth() + 1;
+        const cssCurrentMonth = currentMonth === month ? 'obs-current-month' : '';
+
+        return {
+            year,
+            month,
+            monthNameAndYear,
+            cssCurrentMonth,
+            daysGrid,
+        };
+    });
+}
+
+export function useCalendarYearLogic(app: App | undefined, year: number) {
+    const [files, setFiles] = useState<TFile[]>(
+        () => app?.vault.getMarkdownFiles() || []
+    );
 
     useEffect(() => {
         if (!app) return;
@@ -180,62 +399,12 @@ export function useMonthLogic(app: App | undefined, year: number, month: number)
         };
     }, [app]);
 
-    const metadataCache = app?.metadataCache;
-    const monthStr = month < 10 ? '0' + month : month.toString();
-    const dateStr = `${year}-${monthStr}`;
-
-    const filteredFiles = files.filter((file) => {
-        const eventDate = metadataCache?.getFileCache(file)?.frontmatter?.date;
-        const anniversaryPath = `/Aniversaries/${String(month).padStart(2, '0')}`;
-
-        return (typeof eventDate === 'string' && eventDate.includes(dateStr)) || file.path.includes(anniversaryPath);
-    });
-
-    const firstDayOfMonth = getFirstDayOfMonth(year, month - 1);  // Ajustamos para que el mes esté en el rango correcto
-    const lastDayOfMonth = getLastDayOfMonth(year, month - 1);    // Este método se ajusta aquí también para obtener el último día
-    const numDaysInMonth = lastDayOfMonth.getDate();  // Obtenemos el número de días del mes actual correctamente
-    const firstDayOfWeek = firstDayOfMonth.getDay();  // Día de la semana en el que comienza el mes
-    const dayOffset = getDayOffset(firstDayOfWeek);   // Ajustamos el offset correctamente
-
-    // Calculamos el número de filas necesarias para el calendario, basándonos en el número de días del mes y el desplazamiento
-    const numRows = calculateNumRows(numDaysInMonth, dayOffset);
-
-    // Creamos la cuadrícula de días correctamente, asegurándonos de que no haya días que excedan los límites del mes actual
-    const daysGrid = createDaysGrid({ 
-        app: app as App, 
-        metadataCache: metadataCache as MetadataCache, 
-        files: filteredFiles, 
-        numRows, 
-        numDaysInMonth, 
-        dayOffset, 
-        year, 
-        month 
-    });
-
-    const monthName = `${firstDayOfMonth.toLocaleString('default', { month: 'long' })}`;
-    const monthNameFirstCase = monthName.charAt(0).toUpperCase() + monthName.slice(1);
-    const monthNameAndYear = `${monthNameFirstCase} ${year}`;
-
-    const today = new Date();
-    const currentMonth = today.getMonth() + 1;
-    let cssCurrentMonth = '';
-    if (currentMonth === month) {
-        cssCurrentMonth = 'obs-current-month';
+    if (!app) {
+        return { months: [] as CalendarMonthViewModel[] };
     }
 
-    const monthRef = useRef<HTMLDivElement | null>(null);
+    const index = buildCalendarYearIndex(files, app.metadataCache, year);
+    const months = createCalendarYearMonths(app, index, year);
 
-    useEffect(() => {
-        if (cssCurrentMonth === 'obs-current-month' && monthRef.current) {
-            monthRef.current.scrollIntoView();
-        }
-    }, [cssCurrentMonth]);
-
-    return {
-        monthRef,
-        cssCurrentMonth,
-        monthNameAndYear,
-        daysGrid,
-    };
+    return { months };
 }
-

--- a/src/core/notes/calendar/MonthUI.tsx
+++ b/src/core/notes/calendar/MonthUI.tsx
@@ -1,14 +1,19 @@
-import { useApp } from './../../hooks/useApp';
+import { useEffect, useRef } from 'react';
 import DayUI from './DayUI';
-import { CalendarMonthProps, useMonthLogic } from './Month';
+import { CalendarMonthViewModel } from './Month';
 
-function MonthUI({ year, month }: CalendarMonthProps): JSX.Element {
-    const {
-        monthRef,
-        cssCurrentMonth,
-        monthNameAndYear,
-        daysGrid,
-    } = useMonthLogic(useApp(), year, month);
+function MonthUI({
+    cssCurrentMonth,
+    daysGrid,
+    monthNameAndYear,
+}: CalendarMonthViewModel): JSX.Element {
+    const monthRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+        if (cssCurrentMonth === 'obs-current-month' && monthRef.current) {
+            monthRef.current.scrollIntoView();
+        }
+    }, [cssCurrentMonth]);
 
     return (
         <div ref={monthRef} className={`obs-month ${cssCurrentMonth}`}>


### PR DESCRIPTION
### Objetivo

Consolidar la propiedad de los datos anuales del calendario en `CalendarYear` (Phase 5 de Calendar performance): que un único owner anual prepare los 12 meses y que las vistas mensuales dejen de recalcular índices y suscribirse a listeners de forma individual.

### Cambios

- **`CalendarYear.tsx`**: ahora es el único owner anual. Obtiene la app con `useApp()` y delega la lógica en `useCalendarYearLogic(app, year)`; renderiza los 12 meses preparados como componentes presentacionales `MonthUI` (sin lógica ni suscripciones).
- **`Month.ts`**: alberga `useCalendarYearLogic` (owner anual), `buildCalendarYearIndex` (índice anual con `dailyNoteByDate`, `anniversaryByMonthDay`, `eventsByDate`) y `createCalendarYearMonths` (modelos preparados por mes). Los listeners compartidos se registran una única vez por año: 2 de vault + 1 de metadata.
- **`MonthUI.tsx`**: componente presentacional; recibe los datos del mes ya preparados y conserva únicamente el scroll local.
- **`Month.test.ts`**: reescrita para cubrir el ownership anual, la suscripción única a listeners, el preprocesado anual (fixture de 5 archivos) y la performance de `createDaysGrid`.
- **`CalendarYear.test.tsx`** (nueva): test estructural de que un único owner anual renderiza sus 12 meses preparados.

### Validación

- `npm test -- --runInBand`: 13 suites passed / 86 tests passed.
- `npx tsc --noEmit --skipLibCheck`: exit 0.
- `npm run build`: exit 0.
- `git diff --check`: limpio.

### Notas

- Los helpers legacy (`getDailyNote`, `getAnniversaryNote`, `getDayNotes`, `createDaysGrid`) se conservan; sin callers productivos pendientes.
- `useMonthLogic` queda eliminado: ningún mes vuelve a suscribirse individualmente ni a recalcular índices.
- Sin cambios en `CalendarView.ts`, `Day.ts`, `DayUI.tsx`, Bible o Timeline.
