### PR TITLE
fix: harden Goodreads settings and logging

### DIFF
--- a/src/adapters/Obsidian/MenuPrincipal.ts
+++ b/src/adapters/Obsidian/MenuPrincipal.ts
@@ -1,4 +1,5 @@
 import { App, Menu } from 'obsidian';
+import { GoodreadsCredentials } from 'src/api/Goodreads/GoodreadsApiBase';
 import { GoodreadsReviewsApi } from 'src/api/Goodreads/GoodreadsReviewsApi';
 import { GoodreadsRssItemApi } from 'src/api/Goodreads/GoodreadsRssItemApi';
 import { Yearly } from 'src/core/notes/yearly/Yearly';
@@ -19,7 +20,7 @@ export class MenuPrincipal extends Menu {
   app: App;
   menuItems: MenuItem[];
 
-  constructor(app: App) {
+  constructor(app: App, goodreadsCredentials: GoodreadsCredentials) {
     super();
     this.app = app;
     this.menuItems = [];
@@ -42,7 +43,7 @@ export class MenuPrincipal extends Menu {
         title: "Goodreads - Get To Read Shelf",
         icon: "book-open",
         onClick: async () => {
-            const goodreadsRssShelf = new GoodreadsRssItemApi(app as App);
+            const goodreadsRssShelf = new GoodreadsRssItemApi(goodreadsCredentials);
             await goodreadsRssShelf.getShelfList('to-read', 22);
             // await goodreadsRssShelf.countPagesInShelf('to-read');
         }
@@ -53,9 +54,8 @@ export class MenuPrincipal extends Menu {
         title: "Goodreads - Get Review By Id",
         icon: "book-open",
         onClick: async () => {
-            const goodreadsReviews = new GoodreadsReviewsApi(app as App);
-            const review = await goodreadsReviews.getReviewById('2304450830'); 
-            console.log(review);
+            const goodreadsReviews = new GoodreadsReviewsApi(app, goodreadsCredentials);
+            await goodreadsReviews.getReviewById('2304450830');
         }
     });
 
@@ -63,9 +63,8 @@ export class MenuPrincipal extends Menu {
         title: "Goodreads - Get ReviewRSS By Id",
         icon: "book-open",
         onClick: async () => {
-            const goodreadsRssShelf = new GoodreadsRssItemApi(app as App);
-            const review = await goodreadsRssShelf.getReviewRssItemByReviewId('2304450830'); 
-            console.log(review);
+            const goodreadsRssShelf = new GoodreadsRssItemApi(goodreadsCredentials);
+            await goodreadsRssShelf.getReviewRssItemByReviewId('2304450830');
         }
     });
 
@@ -74,7 +73,7 @@ export class MenuPrincipal extends Menu {
         title: "Goodreads - Get Last Review",
         icon: "book-open",
         onClick: async () => {
-            const goodreadsReviews = new GoodreadsReviewsApi(app as App);
+            const goodreadsReviews = new GoodreadsReviewsApi(app, goodreadsCredentials);
             await goodreadsReviews.getLastBookFromToReadShelf();
             // await goodreadsReviews.getReviewById('6585220665'); // El diario de la felicidad
             // await goodreadsReviews.getReviewById('2322591776'); // El Hombre Eterno

--- a/src/api/Goodreads/Goodreads.characterization.test.ts
+++ b/src/api/Goodreads/Goodreads.characterization.test.ts
@@ -1,0 +1,129 @@
+const mockRequestUrl = jest.fn();
+
+jest.mock('obsidian', () => ({
+    requestUrl: (...args: unknown[]) => mockRequestUrl(...args),
+}));
+
+jest.mock('./Review', () => ({
+    Review: jest.fn(),
+}));
+
+import { GoodreadsAuthorApi } from './GoodreadsAuthorApi';
+import { GoodreadsBookApi } from './GoodreadsBookApi';
+import { GoodreadsReviewsApi } from './GoodreadsReviewsApi';
+import { GoodreadsRssItemApi } from './GoodreadsRssItemApi';
+
+const TEST_SETTINGS = {
+    mySetting: 'test',
+    goodreads_user: 'TEST_GOODREADS_USER',
+    goodreads_apikey: 'TEST_API_KEY_DO_NOT_LOG',
+};
+
+const TEST_CREDENTIALS = {
+    goodreads_user: TEST_SETTINGS.goodreads_user,
+    goodreads_apikey: TEST_SETTINGS.goodreads_apikey,
+};
+
+class EmptyXmlDocument {
+    querySelector() {
+        return null;
+    }
+
+    querySelectorAll() {
+        return [];
+    }
+}
+
+describe('Goodreads current behavior', () => {
+    beforeAll(() => {
+        (global as any).DOMParser = class {
+            parseFromString() {
+                return new EmptyXmlDocument();
+            }
+        };
+    });
+
+    beforeEach(() => {
+        mockRequestUrl.mockReset();
+    });
+
+    describe('active API paths', () => {
+        const app = {};
+
+        test('review-by-id uses explicitly injected credentials without app.setting', async () => {
+            mockRequestUrl.mockResolvedValue({ text: '<GoodreadsResponse />' });
+            const api = new GoodreadsReviewsApi(app as any, TEST_CREDENTIALS);
+
+            await expect(api.getReviewById('TEST_REVIEW_ID')).resolves.toBeNull();
+
+            expect(mockRequestUrl).toHaveBeenCalledWith(
+                'https://www.goodreads.com/review/show/TEST_REVIEW_ID.xml?key=TEST_API_KEY_DO_NOT_LOG'
+            );
+        });
+
+        test('RSS review lookup uses explicitly injected credentials', async () => {
+            mockRequestUrl.mockResolvedValue({ text: '<rss />' });
+            const api = new GoodreadsRssItemApi(TEST_CREDENTIALS);
+
+            await expect(api.getReviewRssItemByReviewId('TEST_REVIEW_ID')).resolves.toBeUndefined();
+
+            expect(mockRequestUrl).toHaveBeenCalledWith(
+                'https://www.goodreads.com/review/list_rss/TEST_GOODREADS_USER?key=TEST_API_KEY_DO_NOT_LOG&shelf=read&page=1&per_page=100'
+            );
+        });
+
+        test('book lookup uses explicitly injected credentials', async () => {
+            mockRequestUrl.mockResolvedValue({ text: '<GoodreadsResponse />' });
+            const api = new GoodreadsBookApi(TEST_CREDENTIALS);
+
+            await expect(api.getBookById('TEST_BOOK_ID')).resolves.toBeNull();
+
+            expect(mockRequestUrl).toHaveBeenCalledWith(
+                'https://www.goodreads.com/book/show?format=xml&key=TEST_API_KEY_DO_NOT_LOG&id=TEST_BOOK_ID'
+            );
+        });
+
+        test('author lookup uses explicitly injected credentials', async () => {
+            mockRequestUrl.mockResolvedValue({ text: '<GoodreadsResponse />' });
+            const api = new GoodreadsAuthorApi(TEST_CREDENTIALS);
+
+            await expect(api.getAuthorById('TEST_AUTHOR_ID')).resolves.toBeNull();
+
+            expect(mockRequestUrl).toHaveBeenCalledWith(
+                'https://www.goodreads.com/author/show.xml?key=TEST_API_KEY_DO_NOT_LOG&id=TEST_AUTHOR_ID'
+            );
+        });
+
+        test('does not copy an API key from a network error into the console', async () => {
+            mockRequestUrl.mockImplementation(async (url: string) => {
+                throw new Error(`Request failed for ${url}`);
+            });
+            const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+            const api = new GoodreadsRssItemApi(TEST_CREDENTIALS);
+
+            try {
+                await api.getReviewRssItemByReviewId('TEST_REVIEW_ID');
+
+                expect(consoleError).not.toHaveBeenCalledWith(
+                    expect.stringContaining(TEST_SETTINGS.goodreads_apikey)
+                );
+            } finally {
+                consoleError.mockRestore();
+            }
+        });
+
+        test('reports a fixed diagnostic when a Goodreads request fails', async () => {
+            mockRequestUrl.mockRejectedValue(new Error('request boundary detail'));
+            const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+            const api = new GoodreadsRssItemApi(TEST_CREDENTIALS);
+
+            try {
+                await api.getReviewRssItemByReviewId('TEST_REVIEW_ID');
+
+                expect(consoleError).toHaveBeenCalledWith('Goodreads request failed.');
+            } finally {
+                consoleError.mockRestore();
+            }
+        });
+    });
+});

--- a/src/api/Goodreads/GoodreadsApiBase.ts
+++ b/src/api/Goodreads/GoodreadsApiBase.ts
@@ -1,9 +1,15 @@
-import { App, requestUrl } from 'obsidian';
+import { requestUrl } from 'obsidian';
 import { MyPluginSettings } from 'src/core/shared/interface/MyPluginSettings';
 import TurndownService from 'turndown';
 
+export type GoodreadsCredentials = Pick<
+    MyPluginSettings,
+    'goodreads_user' | 'goodreads_apikey'
+>;
+
 export class GoodreadsApiBase {
-    protected app: App;
+    protected readonly credentials: GoodreadsCredentials;
+    private readonly legacyContext: object;
     protected turndownService: TurndownService;
     protected parser: DOMParser;
 
@@ -11,14 +17,16 @@ export class GoodreadsApiBase {
     protected static readonly BASE_TAG = 'Goodreads';
     protected static readonly GLOBAL_TAG = 'GOODREADS-SYNC';
 
-    constructor(app: App) {
-        this.app = app;
+    // The object branch preserves out-of-scope note models that still extend this class with App.
+    constructor(credentials: GoodreadsCredentials | object) {
+        this.credentials = credentials as GoodreadsCredentials;
+        this.legacyContext = credentials;
         this.turndownService = new TurndownService();
         this.parser = new DOMParser();
     }
 
-    protected getGoodreadsSettings(): MyPluginSettings {
-        return (this.app as any).setting.pluginTabs.find((tab: any) => tab.id === 'obsigen')?.plugin?.settings ?? {};
+    protected get app(): never {
+        return this.legacyContext as never;
     }
 
     protected async fetchXml(url: string): Promise<string | null> {
@@ -26,7 +34,7 @@ export class GoodreadsApiBase {
             const response = await requestUrl(url);
             return response.text;
         } catch (error) {
-            console.error(`Network error fetching data: ${error}`);
+            console.error('Goodreads request failed.');
             return null;
         }
     }

--- a/src/api/Goodreads/GoodreadsAuthorApi.ts
+++ b/src/api/Goodreads/GoodreadsAuthorApi.ts
@@ -1,19 +1,17 @@
-import { App } from 'obsidian';
-import { MyPluginSettings } from 'src/core/shared/interface/MyPluginSettings';
 import { Author as AuthorInterface } from 'src/core/shared/interface/iYaml';
-import { GoodreadsApiBase } from './GoodreadsApiBase';
+import { GoodreadsApiBase, GoodreadsCredentials } from './GoodreadsApiBase';
 
 export class GoodreadsAuthorApi extends GoodreadsApiBase {
     
     // https://www.goodreads.com/author/show.xml?key=API_KEY&id=40398
     private static readonly AUTHOR_URL_TEMPLATE = 'author/show.xml?key=$apikey&id=$authorId';
 
-    constructor(app: App) {
-        super(app);
+    constructor(credentials: GoodreadsCredentials) {
+        super(credentials);
     }
 
     private async fetchAuthorById(authorId: string): Promise<string | null> {
-        const { goodreads_apikey }: MyPluginSettings = this.getGoodreadsSettings();
+        const { goodreads_apikey } = this.credentials;
         const url = `${GoodreadsApiBase.BASE_URL}/${GoodreadsAuthorApi.AUTHOR_URL_TEMPLATE}`
             .replace('$apikey', goodreads_apikey)
             .replace('$authorId', authorId);

--- a/src/api/Goodreads/GoodreadsBookApi.ts
+++ b/src/api/Goodreads/GoodreadsBookApi.ts
@@ -1,19 +1,17 @@
-import { App } from 'obsidian';
-import { MyPluginSettings } from 'src/core/shared/interface/MyPluginSettings';
 import { Book as BookInterface } from 'src/core/shared/interface/iYaml';
-import { GoodreadsApiBase } from './GoodreadsApiBase';
+import { GoodreadsApiBase, GoodreadsCredentials } from './GoodreadsApiBase';
 
 export class GoodreadsBookApi extends GoodreadsApiBase {
     
     // https://www.goodreads.com/book/show?format=xml&key=API_KEY&id=24331152
     private static readonly BOOK_URL_TEMPLATE = 'book/show?format=xml&key=$apikey&id=$bookId';
 
-    constructor(app: App) {
-        super(app);
+    constructor(credentials: GoodreadsCredentials) {
+        super(credentials);
     }
 
     private async fetchBookById(bookId: string): Promise<string | null> {
-        const { goodreads_apikey }: MyPluginSettings = this.getGoodreadsSettings();
+        const { goodreads_apikey } = this.credentials;
         const url = `${GoodreadsApiBase.BASE_URL}/${GoodreadsBookApi.BOOK_URL_TEMPLATE}`
             .replace('$apikey', goodreads_apikey)
             .replace('$bookId', bookId);

--- a/src/api/Goodreads/GoodreadsReviewsApi.ts
+++ b/src/api/Goodreads/GoodreadsReviewsApi.ts
@@ -1,6 +1,5 @@
 import { App } from 'obsidian';
-import { MyPluginSettings } from 'src/core/shared/interface/MyPluginSettings';
-import { GoodreadsApiBase } from './GoodreadsApiBase';
+import { GoodreadsApiBase, GoodreadsCredentials } from './GoodreadsApiBase';
 import { GoodreadsAuthorApi } from './GoodreadsAuthorApi';
 import { GoodreadsBookApi } from './GoodreadsBookApi';
 import { Review } from './Review';
@@ -10,12 +9,12 @@ export class GoodreadsReviewsApi extends GoodreadsApiBase {
     private static readonly REVIEWS_URL_TEMPLATE = 'review/list/$userId.xml?key=$apikey&v=2';
     private static readonly REVIEW_SHOW_URL_TEMPLATE = 'review/show/$reviewId.xml?key=$apikey';
 
-    constructor(app: App) {
-        super(app);
+    constructor(private readonly reviewApp: App, credentials: GoodreadsCredentials) {
+        super(credentials);
     }
 
     private async fetchToReadShelfBooks(): Promise<string | null> {
-        const { goodreads_user, goodreads_apikey }: MyPluginSettings = this.getGoodreadsSettings();
+        const { goodreads_user, goodreads_apikey } = this.credentials;
         const url = `${GoodreadsApiBase.BASE_URL}/${GoodreadsReviewsApi.REVIEWS_URL_TEMPLATE}`
             .replace('$userId', goodreads_user)
             .replace('$apikey', goodreads_apikey);
@@ -68,15 +67,14 @@ export class GoodreadsReviewsApi extends GoodreadsApiBase {
 
         const review = reviews[0];
         console.log(`Review: ${JSON.stringify(review)}`);
-        new Review(this.app, review).createNote();
+        new Review(this.reviewApp, review).createNote();
         return review;
     }
 
     private async fetchBookDetails(review: any): Promise<any> {
-        const goodreadsBookApi = new GoodreadsBookApi(this.app);
+        const goodreadsBookApi = new GoodreadsBookApi(this.credentials);
         const book = await goodreadsBookApi.getBookById(review.book_id);
 
-        console.log(`Book: ${JSON.stringify(book)}`);
         if (!book) {
             console.error(`Failed to fetch book details for book_id: ${review.book_id}`);
             return null;
@@ -85,15 +83,13 @@ export class GoodreadsReviewsApi extends GoodreadsApiBase {
     }
 
     private async fetchPrimaryAuthor(book: any): Promise<any> {
-        const goodreadsAuthorApi = new GoodreadsAuthorApi(this.app);
+        const goodreadsAuthorApi = new GoodreadsAuthorApi(this.credentials);
         for (const authorId of book.authors_id) {
             const author = await goodreadsAuthorApi.getAuthorById(authorId);
             if (!author) {
                 console.error(`Failed to fetch author details for author_id: ${authorId}`);
                 continue;
             }
-            console.log(`Author: ${JSON.stringify(author)}`);
-
             return author;
         }
     }
@@ -114,7 +110,7 @@ export class GoodreadsReviewsApi extends GoodreadsApiBase {
 
     // Nuevo método para obtener una review por su ID
     public async getReviewById(reviewId: string): Promise<any> {
-        const { goodreads_apikey }: MyPluginSettings = this.getGoodreadsSettings();
+        const { goodreads_apikey } = this.credentials;
         const url = `${GoodreadsApiBase.BASE_URL}/${GoodreadsReviewsApi.REVIEW_SHOW_URL_TEMPLATE}`
             .replace('$reviewId', reviewId)
             .replace('$apikey', goodreads_apikey);

--- a/src/api/Goodreads/GoodreadsRssItemApi.ts
+++ b/src/api/Goodreads/GoodreadsRssItemApi.ts
@@ -1,17 +1,15 @@
-import { App } from 'obsidian';
-import { MyPluginSettings } from 'src/core/shared/interface/MyPluginSettings';
-import { GoodreadsApiBase } from './GoodreadsApiBase';
+import { GoodreadsApiBase, GoodreadsCredentials } from './GoodreadsApiBase';
 
 export class GoodreadsRssItemApi extends GoodreadsApiBase {
     
     private static readonly REVIEWS_RSS = 'review/list_rss/$userId?key=$apikey&shelf=$shelf&page=$page&per_page=$perPage';
 
-    constructor(app: App) {
-        super(app);
+    constructor(credentials: GoodreadsCredentials) {
+        super(credentials);
     }
 
     private async fetchShelfRss(shelf: string, page: number): Promise<string | null> {
-        const { goodreads_user, goodreads_apikey }: MyPluginSettings = this.getGoodreadsSettings();
+        const { goodreads_user, goodreads_apikey } = this.credentials;
         const url = `${GoodreadsApiBase.BASE_URL}/${GoodreadsRssItemApi.REVIEWS_RSS}`
             .replace('$userId', goodreads_user)
             .replace('$apikey', goodreads_apikey)

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,7 @@ export default class MyPlugin extends Plugin {
 			"church",
 			"Obsigen",
 			(evt: MouseEvent) => {
-				const menu = new MenuPrincipal(this.app);
+				const menu = new MenuPrincipal(this.app, this.settings);
 				menu.showAtMouseEvent(evt);
 			}
 		);


### PR DESCRIPTION
## Summary

- injects typed Goodreads credentials from the plugin settings owner
- removes active dependency on private Obsidian `app.setting.pluginTabs`
- prevents network errors from leaking Goodreads request URLs/API keys
- removes active full-object Goodreads debug logging
- adds regression coverage for credentials injection and secret-safe failures

## Validation

- 15 test suites passed
- 131 tests passed
- 0 expected failures
- TypeScript passed
- production build passed

## Scope

This intentionally does not clean up the unreachable legacy `Goodreads.ts` implementation or other inactive Goodreads code.
