### PR TITLE
docs: refresh project documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-OUTPUT_DIR=/mnt/c/Users/jesus/Documents/vault/.obsidian/plugins/obsigen
+OUTPUT_DIR=/path/to/vault/.obsidian/plugins/obsigen

--- a/README.md
+++ b/README.md
@@ -1,234 +1,103 @@
 # Obsigen
 
-[![react](https://img.shields.io/badge/React-61DBFB?style=for-the-badge&logo=react&logoColor=black)](https://reactjs.org/)
-[![typescript](https://img.shields.io/badge/TypeScript-3178C6?style=for-the-badge&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
-[![styledcomponents](https://img.shields.io/badge/styled_components-DB7093?style=for-the-badge&logo=styledcomponents&logoColor=white)](https://styled-components.com/)
-[![obsidian](https://img.shields.io/badge/obsidian-7C3AED?style=for-the-badge&logo=obsidian&logoColor=white)](https://obsidian.md/)
-[![docker](https://img.shields.io/badge/docker-2496ED?style=for-the-badge&logo=docker&logoColor=white)](https://www.docker.com/)
-[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/jesuserro/obsigen?style=for-the-badge&sort=semver)](https://github.com/jesuserro/obsigen/releases/)
-[![GitHub issues](https://img.shields.io/github/issues/jesuserro/obsigen?style=for-the-badge)](https://github.com/jesuserro/obsigen/issues/)
+[![CI](https://github.com/jesuserro/obsigen/actions/workflows/ci.yml/badge.svg)](https://github.com/jesuserro/obsigen/actions/workflows/ci.yml)
+[![Obsidian](https://img.shields.io/badge/Obsidian-%3E%3D%201.7.2-7C3AED?logo=obsidian)](https://obsidian.md/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 
-Displaying your Obsidian notes in a year calendar view through icons.
-Use the yaml frontmatter to add the date and icon to your notes. The plugin will read the yaml and display the notes in the calendar view. The icon is defined on "tag" property.
+Obsigen is a personal Obsidian plugin for navigating dated notes through a calendar, browsing Bible notes, and displaying historical notes on a timeline.
 
-## Folder Structure
+## What it does
 
-Following the DDD principles, the project is divided into three layers: core, adapters and shared.
+### Calendar
 
-```
-📦obsigen
- ┣📦src
- ┣ 📂adapters
- ┃ ┗ 📂Obsidian
- ┃ ┃ ┣ 📜MenuPrincipal.ts
- ┃ ┃ ┣ 📜PromptModal.ts
- ┃ ┃ ┣ 📜SampleModal.ts
- ┃ ┃ ┗ 📜SampleSettingTab.ts
- ┣ 📂assets
- ┃ ┗ 📜church.js
- ┣ 📂core
- ┃ ┣ 📂hooks
- ┃ ┃ ┗ 📜useApp.ts
- ┃ ┣ 📂notes
- ┃ ┃ ┣ 📂__mocks__
- ┃ ┃ ┃ ┗ 📜obsidian.ts
- ┃ ┃ ┣ 📂aniversario
- ┃ ┃ ┃ ┣ 📜Aniversario.test.ts
- ┃ ┃ ┃ ┗ 📜Aniversario.ts
- ┃ ┃ ┣ 📂biblia
- ┃ ┃ ┃ ┗ 📂versiculo
- ┃ ┃ ┣ 📂calendar
- ┃ ┃ ┃ ┣ 📜Calendar.ts
- ┃ ┃ ┃ ┣ 📜CalendarDay.scss
- ┃ ┃ ┃ ┣ 📜CalendarDay.tsx
- ┃ ┃ ┃ ┣ 📜CalendarEvent.scss
- ┃ ┃ ┃ ┣ 📜CalendarEvent.ts
- ┃ ┃ ┃ ┣ 📜CalendarIcon.scss
- ┃ ┃ ┃ ┣ 📜CalendarIcon.tsx
- ┃ ┃ ┃ ┣ 📜CalendarMonth.scss
- ┃ ┃ ┃ ┣ 📜CalendarMonth.tsx
- ┃ ┃ ┃ ┣ 📜CalendarTitle.tsx
- ┃ ┃ ┃ ┣ 📜CalendarView.ts
- ┃ ┃ ┃ ┣ 📜CalendarYear.scss
- ┃ ┃ ┃ ┣ 📜CalendarYear.tsx
- ┃ ┃ ┃ ┗ 📜calendar.scss
- ┃ ┃ ┣ 📂captureUrl
- ┃ ┃ ┃ ┣ 📜CaptureUrl.test.ts
- ┃ ┃ ┃ ┣ 📜CaptureUrl.ts
- ┃ ┃ ┃ ┣ 📜CaptureUrlModal.scss
- ┃ ┃ ┃ ┗ 📜CaptureUrlModal.ts
- ┃ ┃ ┣ 📂daily
- ┃ ┃ ┃ ┗ 📜Daily.ts
- ┃ ┃ ┣ 📂momento
- ┃ ┃ ┃ ┗ 📜Momento.ts
- ┃ ┃ ┣ 📜NoteGenerator.test.ts
- ┃ ┃ ┗ 📜NoteGenerator.ts
- ┃ ┗ 📂shared
- ┃ ┃ ┣ 📂interface
- ┃ ┃ ┃ ┣ 📜MyPluginSettings.ts
- ┃ ┃ ┃ ┗ 📜iYaml.ts
- ┃ ┃ ┣ 📂templates
- ┃ ┃ ┃ ┗ 📜Yaml.tsx
- ┃ ┃ ┗ 📜appContext.ts
- ┣ 📂ui
- ┃ ┗ 📜common.scss
- ┣ 📜main.ts
- ┣ 📜styles.css
- ┗ 📜styles.scss
- ┣ 📂var
- ┃ ┣ 📜MonthView.ts
- ┃ ┣ 📜NoteGenerator.ts
- ┃ ┣ 📜NoteGeneratorAllInOne.ts
- ┃ ┣ 📜NoteGeneratorCaller.ts
- ┃ ┗ 📜template.yaml
- ┣ 📜.babelrc
- ┣ 📜.editorconfig
- ┣ 📜.eslintignore
- ┣ 📜.eslintrc
- ┣ 📜.gitignore
- ┣ 📜.npmrc
- ┣ 📜README.md
- ┣ 📜babel.config.js
- ┣ 📜esbuild.config.mjs
- ┣ 📜jest.config.js
- ┣ 📜manifest.json
- ┣ 📜package-lock.json
- ┣ 📜package.json
- ┣ 📜tsconfig.json
- ┣ 📜version-bump.mjs
- ┗ 📜versions.json
+The calendar displays a full year as monthly grids. It associates daily notes and event notes with dates, opens matching vault notes, and provides an event form from each day.
+
+### Bible
+
+The Bible view provides book and chapter navigation. It hydrates the structure with matching vault notes and cover metadata, then opens the corresponding note when an entry is selected.
+
+### Timeline
+
+The timeline displays historical Bible notes with cover metadata and links back to their vault notes. Entries use this frontmatter contract:
+
+```yaml
+historical_date: "-2066-01-01"
 ```
 
-## Installation
+Unsigned years represent AD dates. A leading minus sign represents BC dates.
 
-To install and set up the "Obsigen" project on a new environment using Ubuntu on WSL2, follow these steps:
+### Additional note utilities
 
-### Step 1: Install Node.js and npm
+The plugin menu also exposes focused utilities for daily and yearly notes, anniversaries, favorites, and event creation.
+
+## Status
+
+Obsigen is primarily a personal Obsidian plugin and an experimental project. The repository is kept buildable and usable, but several data and folder conventions are tailored to the author's vault.
+
+Obsigen is not currently listed in the Obsidian Community Plugins directory. Install it manually using the steps below.
+
+## Requirements
+
+- Obsidian 1.7.2 or newer
+- Node.js 22 and npm to build from source
+
+## Manual installation
+
+First, build the plugin from source:
 
 ```bash
-# Update the system and repositories
-sudo apt update
-sudo apt upgrade
-
-# Install Node.js (LTS version)
-curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
-sudo apt install -y nodejs
-
-# Verify the installation
-node -v
-npm -v
-```
-
-### Step 2: Clone the repository
-
-```bash
-# Navigate to your working directory
-cd ~
-
-# Clone the GitHub repository
 git clone https://github.com/jesuserro/obsigen.git
 cd obsigen
-```
-
-### Step 3: Install project dependencies
-
-```bash
-# Install all dependencies listed in package.json
-npm install
-```
-
-### Step 4: Create the `dataurls.ts` file
-
-To generate the `dataurls.ts` file in the `src/assets/icons` folder, run the following commands:
-
-```bash
-# Create the directory if it doesn't exist
-mkdir -p src/assets/icons
-
-# Create the dataurls.ts file
-touch src/assets/icons/dataurls.ts
-
-# Optional: Add an initial comment to the file
-echo "// Placeholder for data URLs" > src/assets/icons/dataurls.ts
-```
-
-### Step 5: Configure the environment variables
-
-Create a .env file in the root of your project by copying the provided .env.example:
-
-```bash
-cp .env.example .env
-
-#Edit the .env file to set the output directory path:
-OUTPUT_DIR=/mnt/c/Users/jesus/Documents/vault/.obsidian/plugins/obsigen
-```
-
-### Step 6: Install dotenv and create the tsconfig and copy scripts
-
-Install dotenv:
-
-```bash
-npm install dotenv --save
-```
-
-### Step 7: Install missing dependencies
-
-Ensure you have turndown and its type declarations installed:
-
-```bash
-# Install turndown and its type declarations
-npm install turndown --save
-npm install @types/turndown --save-dev
-```
-
-### Step 8: Clean and rebuild the project
-
-Clean the cache and rebuild the project to ensure all dependencies are properly configured:
-
-```bash
-# Clean TypeScript cache and node_modules
-rm -rf node_modules
-rm -rf dist
-npm install
-
-# Rebuild the project
+npm ci
 npm run build
 ```
 
-### Step 9: Run the development environment
+The build creates `main.js` and `styles.css` in the repository root. `manifest.json` is already present there.
+
+To install the result:
+
+1. Create `<vault>/.obsidian/plugins/obsigen/`.
+2. Copy `main.js`, `manifest.json`, and `styles.css` into that directory.
+3. Restart Obsidian or reload the app.
+4. Enable Obsigen under **Settings → Community plugins**.
+
+## Development
+
+Install the locked dependencies before running the development commands:
 
 ```bash
-# Start the development environment
-npm run dev
+npm ci
 ```
 
-### (Optional) Update npm
+- `npm test` runs the Jest test suite.
+- `npm run typecheck` checks the TypeScript project without emitting files.
+- `npm run build` creates a minified production bundle and compressed CSS.
+- `npm run dev` watches the TypeScript and Sass sources for changes.
+
+Private icon assets are optional. A clean public checkout generates an empty icon map automatically, while local PNG files remain ignored by Git.
+
+## Optional local deployment
+
+The standard build does not require `.env` or a vault path. To copy a completed build into a local plugin directory, set `OUTPUT_DIR` in `.env` or in the process environment:
+
+```dotenv
+OUTPUT_DIR=/path/to/vault/.obsidian/plugins/obsigen
+```
+
+Then run:
 
 ```bash
-# Update npm to the latest version
-sudo npm install -g npm@latest
+npm run build
+npm run deploy:local
 ```
 
-By following these steps, you should have your project configured and ready to use in your new environment. If you encounter any issues or need further assistance, feel free to consult the documentation or open an issue on the repository.
+The deployment command copies only `main.js`, `manifest.json`, and `styles.css`.
 
 ## Links
 
-- [Use React in your plugin](https://docs.obsidian.md/Plugins/Getting+started/Use+React+in+your+plugin)
-
-### Icons
-
-- [Obsidian Icons](https://docs.obsidian.md/Plugins/User+interface/Icons)
-- [React Icons](https://react-icons.github.io/react-icons/)
-- [Lucide](https://lucide.dev/icons/)
-- [Hexadecimal Color Picker](https://www.google.com/search?q=hexadecimal+color+picker)
-
-## Inspired by
-
-- [Obsidian Full Calendar](https://github.com/davish/obsidian-full-calendar)
-- [Full Calendar](https://github.com/fullcalendar/fullcalendar)
-- [Full Calendar Demos](https://fullcalendar.io/demos)
-- [ODIN - Obsidian Driven Information Network](https://github.com/memgraph/odin)
+- [Obsidian plugin developer documentation](https://docs.obsidian.md/Plugins/Getting+started/Build+a+plugin)
+- [Issue tracker](https://github.com/jesuserro/obsigen/issues)
 
 ## Funding
 
-[![Buy Me a Coffee](https://img.shields.io/badge/-Buy%20Me%20a%20Coffee-orange?style=flat&logo=buy-me-a-coffee&logoColor=white)](https://www.buymeacoffee.com/jesuserro)
+If Obsigen is useful to you, you can [support its development](https://www.buymeacoffee.com/jesuserro).

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 	"name": "Obsigen",
 	"version": "0.0.3",
 	"minAppVersion": "1.7.2",
-	"description": "View your notes in Calendar.",
+	"description": "Calendar, Bible and historical timeline views for personal Obsidian notes.",
 	"author": "Jesús Erro",
 	"authorUrl": "https://buymeacoffee.com/jesuserro",
 	"fundingUrl": "https://buymeacoffee.com/jesuserro",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "obsigen",
 	"version": "0.0.3",
-	"description": "Just another customized digital garden.",
+	"description": "Personal Obsidian plugin for calendar, Bible and historical timeline note navigation.",
 	"main": "main.js",
 	"scripts": {
 		"dev": "concurrently \"npm run dev:js\" \"npm run dev:css\"",
@@ -17,7 +17,7 @@
 		"iconos": "node src/createPrivateIcons.mjs"
 	},
 	"keywords": [],
-	"author": "",
+	"author": "Jesús Erro",
 	"license": "MIT",
 	"devDependencies": {
 		"@types/jest": "^29.5.2",


### PR DESCRIPTION
## Summary

- rewrites the README around the maintained Calendar, Bible and Timeline features
- replaces obsolete WSL/personal-path setup with the standard build workflow
- aligns package and plugin descriptions with the current project
- documents manual installation, development and optional local deployment

## Validation

- npm ci
- 131 tests
- typecheck
- production build