### PR TITLE
chore: modernize TypeScript module resolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,12 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "inlineSourceMap": true,
     "inlineSources": false,
     "noImplicitAny": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
+    "paths": {
+      "src/*": ["./src/*"]
+    },
     "importHelpers": true,
     "isolatedModules": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

- replaces deprecated TypeScript Node 10 module resolution with bundler resolution
- replaces baseUrl-based `src/*` resolution with an explicit path mapping
- removes TypeScript 7 deprecation warnings without suppressing them

## Validation

- 131 tests
- TypeScript passed
- production build passed
- CI passed